### PR TITLE
Add more test cases for between command

### DIFF
--- a/internal/cmd/between.go
+++ b/internal/cmd/between.go
@@ -77,14 +77,14 @@ types are: YAML (http://yaml.org/) and JSON (http://json.org/).
 			betweenCmdSettings.chrootTo = betweenCmdSettings.chroot
 		}
 
-		// Change root of from input file if change root flag for form is set
+		// Change root of 'from' input file if change root flag for 'from' is set
 		if betweenCmdSettings.chrootFrom != "" {
 			if err = dyff.ChangeRoot(&from, betweenCmdSettings.chrootFrom, betweenCmdSettings.translateListToDocuments); err != nil {
-				return wrap.Errorf(err, "Failed to change root of %s to path %s", from.Location, betweenCmdSettings.chrootFrom)
+				return wrap.Errorf(err, "failed to change root of %s to path %s", from.Location, betweenCmdSettings.chrootFrom)
 			}
 		}
 
-		// Change root of to input file if change root flag for to is set
+		// Change root of 'to' input file if change root flag for 'to' is set
 		if betweenCmdSettings.chrootTo != "" {
 			if err = dyff.ChangeRoot(&to, betweenCmdSettings.chrootTo, betweenCmdSettings.translateListToDocuments); err != nil {
 				return wrap.Errorf(err, "failed to change root of %s to path %s", to.Location, betweenCmdSettings.chrootTo)

--- a/internal/cmd/cmd_suite_test.go
+++ b/internal/cmd/cmd_suite_test.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	. "github.com/homeport/dyff/internal/cmd"
@@ -48,6 +49,20 @@ func createTestFile(input string) string {
 	Expect(err).To(BeNil())
 
 	return file.Name()
+}
+
+func assets(pathElement ...string) string {
+	targetPath := filepath.Join(append(
+		[]string{"..", "..", "assets"},
+		pathElement...,
+	)...)
+
+	abs, err := filepath.Abs(targetPath)
+	if err != nil {
+		return targetPath
+	}
+
+	return abs
 }
 
 func captureStdout(f func() error) (string, error) {


### PR DESCRIPTION
There are still use cases that are not covered by tests.

Add test case that uses `--chroot` flag.

Add test case that checks error condition for `--chroot` in `from`.

Add test case that checks error condition for `--chroot` in `to`.