### PR TITLE
fix path for `go get` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ curl --silent --location https://goo.gl/DRXDVN | bash
 And of course, you can download and build `dyff` from source using `go`:
 
 ```bash
-go get github.com/homeport/dyff
+go get github.com/homeport/dyff/cmd/dyff
 ```
 
 ## Use cases and examples


### PR DESCRIPTION
This PR fixes `go get` example in README.
Since 57ca16e, `go get`'s path looks like it should be `github.com/homeport/dyff/cmd/dyff`.