### PR TITLE
Example of embedding dyff into git

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ go get github.com/homeport/dyff/cmd/dyff
       https://raw.githubusercontent.com/cloudfoundry/cf-deployment/v1.20.0/cf-deployment.yml
     ```
 
-- Embed dyff into git for better undertsandable diffs
+- Embed `dyff` into git for better understandable differences
 
     ```bash
     # Setup...
-    git config --local diff.dyff.command 'dyff_between() { dyff --color on between "$2" "$5"; }; dyff_between'
+    git config --local diff.dyff.command 'dyff_between() { dyff --color on between --omit-header "$2" "$5"; }; dyff_between'
     echo '*.yml diff=dyff' >> .gitattributes
     
     # And have fun, e.g.:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ go get github.com/homeport/dyff/cmd/dyff
       https://raw.githubusercontent.com/cloudfoundry/cf-deployment/v1.20.0/cf-deployment.yml
     ```
 
+- Embed dyff into git for better undertsandable diffs
+
+    ```bash
+    # Setup...
+    git config --local diff.dyff.command 'dyff_between() { dyff --color on between "$2" "$5"; }; dyff_between'
+    echo '*.yml diff=dyff' >> .gitattributes
+    
+    # And have fun, e.g.:
+    git log --ext-diff -u
+    git show --ext-diff HEAD
+    ```
+
 - Convert a JSON stream to YAML
 
     ```bash


### PR DESCRIPTION
Works rather well but unfortunately dyff does not allow hiding header with ASCII graphics dyff logo.
This header is displayed each change when browsing `git log --ext-diff -u` and takes quite much space.