### PR TITLE
Add ignore order changes flag

### DIFF
--- a/internal/cmd/between.go
+++ b/internal/cmd/between.go
@@ -154,6 +154,7 @@ func init() {
 
 	// General `dyff` package related preferences
 	betweenCmd.PersistentFlags().BoolVarP(&dyff.UseGoPatchPaths, "use-go-patch-style", "g", false, "use Go-Patch style paths in outputs")
+	betweenCmd.PersistentFlags().BoolVarP(&dyff.IgnoreOrderChanges, "ignore-order-changes", "i", false, "ignore order changes in lists")
 
 	// Input documents modification flags
 	betweenCmd.PersistentFlags().BoolVar(&betweenCmdSettings.swap, "swap", false, "Swap 'from' and 'to' for comparison")

--- a/internal/cmd/cmds_test.go
+++ b/internal/cmd/cmds_test.go
@@ -295,5 +295,17 @@ list
 
 `))
 		})
+
+		It("should ignore order changes if respective flag is set", func() {
+			from := createTestFile(`{"list":[{"name":"one"},{"name":"two"},{"name":"three"}]}`)
+			defer os.Remove(from)
+
+			to := createTestFile(`{"list":[{"name":"one"},{"name":"three"},{"name":"two"}]}`)
+			defer os.Remove(to)
+
+			out, err := dyff("between", "--omit-header", "--ignore-order-changes", from, to)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(BeEquivalentTo("\n"))
+		})
 	})
 })

--- a/pkg/dyff/core.go
+++ b/pkg/dyff/core.go
@@ -46,6 +46,9 @@ var MinorChangeThreshold = 0.1
 // UseGoPatchPaths style paths instead of Spruce Dot-Style
 var UseGoPatchPaths = false
 
+// IgnoreOrderChanges disables the detection for changes of the order in lists
+var IgnoreOrderChanges = false
+
 // CompareInputFiles is one of the convenience main entry points for comparing
 // objects. In this case the representation of an input file, which might
 // contain multiple documents. It returns a report with the list of differences.
@@ -351,9 +354,14 @@ func compareNamedEntryLists(path ytbx.Path, identifier string, from *yamlv3.Node
 		}
 	}
 
-	orderchanges := findOrderChangesInNamedEntryLists(fromNames, toNames)
-
-	return packChangesAndAddToResult(result, true, path, orderchanges, additions, removals)
+	return packChangesAndAddToResult(
+		result,
+		true,
+		path,
+		findOrderChangesInNamedEntryLists(fromNames, toNames),
+		additions,
+		removals,
+	)
 }
 
 func compareNodeValues(path ytbx.Path, from *yamlv3.Node, to *yamlv3.Node) ([]Diff, error) {
@@ -373,6 +381,10 @@ func compareNodeValues(path ytbx.Path, from *yamlv3.Node, to *yamlv3.Node) ([]Di
 }
 
 func findOrderChangesInSimpleList(from, to *yamlv3.Node, fromNames, toNames []uint64, fromLookup, toLookup map[uint64]int) []Detail {
+	if IgnoreOrderChanges {
+		return []Detail{}
+	}
+
 	orderchanges := make([]Detail, 0)
 
 	cnv := func(list []uint64, lookup map[uint64]int, content *yamlv3.Node) *yamlv3.Node {
@@ -423,6 +435,10 @@ func AsSequenceNode(list []string) *yamlv3.Node {
 }
 
 func findOrderChangesInNamedEntryLists(fromNames, toNames []string) []Detail {
+	if IgnoreOrderChanges {
+		return []Detail{}
+	}
+
 	orderchanges := make([]Detail, 0)
 
 	idxLookupMap := make(map[string]int, len(toNames))

--- a/pkg/dyff/core.go
+++ b/pkg/dyff/core.go
@@ -291,7 +291,6 @@ func compareSimpleLists(path ytbx.Path, from *yamlv3.Node, to *yamlv3.Node) ([]D
 
 	return packChangesAndAddToResult(
 		result,
-		true,
 		path,
 		findOrderChangesInSimpleList(from, to, fromNames, toNames, fromLookup, toLookup),
 		additions,
@@ -356,7 +355,6 @@ func compareNamedEntryLists(path ytbx.Path, identifier string, from *yamlv3.Node
 
 	return packChangesAndAddToResult(
 		result,
-		true,
 		path,
 		findOrderChangesInNamedEntryLists(fromNames, toNames),
 		additions,
@@ -461,7 +459,7 @@ func findOrderChangesInNamedEntryLists(fromNames, toNames []string) []Detail {
 	return orderchanges
 }
 
-func packChangesAndAddToResult(list []Diff, prepend bool, path ytbx.Path, orderchanges []Detail, additions, removals []*yamlv3.Node) ([]Diff, error) {
+func packChangesAndAddToResult(list []Diff, path ytbx.Path, orderchanges []Detail, additions, removals []*yamlv3.Node) ([]Diff, error) {
 	// Prepare a diff for this path to added to the result set (if there are changes)
 	diff := Diff{Path: path, Details: []Detail{}}
 
@@ -493,17 +491,10 @@ func packChangesAndAddToResult(list []Diff, prepend bool, path ytbx.Path, orderc
 		})
 	}
 
-	// If there were changes added to the details list,
-	// we can safely add it to the result set.
-	// Otherwise it the result set will be returned as-is.
+	// If there were changes added to the details list, we can safely add it to
+	// the result set. Otherwise it the result set will be returned as-is.
 	if len(diff.Details) > 0 {
-		switch prepend {
-		case true:
-			list = append([]Diff{diff}, list...)
-
-		case false:
-			list = append(list, diff)
-		}
+		list = append([]Diff{diff}, list...)
 	}
 
 	return list, nil

--- a/pkg/dyff/output_human_test.go
+++ b/pkg/dyff/output_human_test.go
@@ -23,12 +23,12 @@ package dyff_test
 import (
 	"fmt"
 
+	. "github.com/gonvenience/bunt"
+	. "github.com/homeport/dyff/pkg/dyff"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "github.com/gonvenience/bunt"
 	"github.com/gonvenience/ytbx"
-	. "github.com/homeport/dyff/pkg/dyff"
 )
 
 var _ = Describe("human readable report", func() {
@@ -108,19 +108,22 @@ input: |+
 			compareAgainstExpected("../../assets/binary/from.yml",
 				"../../assets/binary/to.yml",
 				"../../assets/binary/dyff.expected",
-				false)
+				false,
+			)
 		})
 
 		It("should show the testbed results as expected", func() {
 			compareAgainstExpected("../../assets/testbed/from.yml",
 				"../../assets/testbed/to.yml",
 				"../../assets/testbed/expected-dyff-spruce.human",
-				false)
+				false,
+			)
 
 			compareAgainstExpected("../../assets/testbed/from.yml",
 				"../../assets/testbed/to.yml",
 				"../../assets/testbed/expected-dyff-gopatch.human",
-				true)
+				true,
+			)
 		})
 	})
 
@@ -140,7 +143,8 @@ input: |+
 				"../../assets/colors/from.yml",
 				"../../assets/colors/to.yml",
 				"../../assets/colors/dyff.expected",
-				false)
+				false,
+			)
 		})
 	})
 
@@ -189,7 +193,8 @@ variables.ROUTER_TLS_PEM.options
 			compareAgainstExpected("../../assets/issues/issue-89/from.yml",
 				"../../assets/issues/issue-89/to.yml",
 				"../../assets/issues/issue-89/expected-dyff-spruce.human",
-				false)
+				false,
+			)
 		})
 	})
 })


### PR DESCRIPTION
Based on feedback in #108, there are use cases where the order changes
in a list are not important to be reported. It should be possible to
ignore changes to the order of a list.

Add flag to ignore order changes for the `between` command.

Add new test case to verify new command flag.

Add global option in `dyff` package to disable order change detection.

Introduce short circuit to bypass the order change detection.

Refactor return statement for named entry lists to unify the style.