### PR TITLE
Add/filter reports

### DIFF
--- a/internal/cmd/between.go
+++ b/internal/cmd/between.go
@@ -91,6 +91,20 @@ types are: YAML (http://yaml.org/) and JSON (http://json.org/).
 			return wrap.Errorf(err, "failed to compare input files")
 		}
 
+		if reportOptions.filters != nil {
+			var filterPaths []ytbx.Path
+
+			for _, pathString := range reportOptions.filters {
+				path, err := ytbx.ParseGoPatchStylePathString(pathString)
+
+				if err != nil {
+					return wrap.Errorf(err, "failed to set path filter, because path %s cannot be parsed", pathString)
+				}
+
+				filterPaths = append(filterPaths, path)
+			}
+			report = report.Filter(filterPaths...)
+		}
 		return writeReport(cmd, report)
 	},
 }

--- a/internal/cmd/cmds_test.go
+++ b/internal/cmd/cmds_test.go
@@ -484,6 +484,26 @@ example_two
 			Expect(ok).To(BeTrue())
 			Expect(exitCode.Value).To(Equal(255))
 		})
+
+		It("should accept a list of paths and filter the report based on these", func() {
+			out, err := dyff("between", "--omit-header", "--filter", "/yaml/map/whitespaces,/yaml/map/type-change-1", assets("examples", "from.yml"), assets("examples", "to.yml"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(BeEquivalentTo(`
+yaml.map.type-change-1
+  ± type change from string to int
+    - string
+    + 147
+
+yaml.map.whitespaces
+  ± whitespace only change
+    - Strings·can··have·whitespaces.     + Strings·can··have·whitespaces.↵
+                                           ↵
+                                           ↵
+
+
+`,
+			))
+		})
 	})
 
 	Context("last-applied command", func() {

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -50,6 +50,7 @@ type reportConfig struct {
 	exitWithCode              bool
 	omitHeader                bool
 	useGoPatchPaths           bool
+	filters                   []string
 }
 
 var reportOptions reportConfig
@@ -58,6 +59,7 @@ func applyReportOptionsFlags(cmd *cobra.Command) {
 	// Compare options
 	cmd.Flags().BoolVarP(&reportOptions.ignoreOrderChanges, "ignore-order-changes", "i", false, "ignore order changes in lists")
 	cmd.Flags().BoolVarP(&reportOptions.kubernetesEntityDetection, "detect-kubernetes", "", false, "detect kubernetes entities")
+	cmd.Flags().StringSliceVar(&reportOptions.filters, "filter", nil, "filter reports to a subset of differences based on supplied arguments")
 
 	// Main output preferences
 	cmd.Flags().StringVarP(&reportOptions.style, "output", "o", defaultOutputStyle, "specify the output style, supported styles: human, or brief")

--- a/pkg/dyff/compare_test.go
+++ b/pkg/dyff/compare_test.go
@@ -726,6 +726,23 @@ listY: [ Yo, Yo, Yo ]
 
 				Expect(orderChangeDiffs).To(BeEquivalentTo(0))
 			})
+
+			It("should filter my report based on set of paths", func() {
+				pathString := "/yaml/map/foobar"
+				p := path(pathString)
+
+				report := Report{Diffs: []Diff{
+					singleDiff(pathString, ADDITION, nil, "foobar"),
+					singleDiff("/yaml/map/barfoo", ADDITION, nil, "barfoo"),
+				}}
+
+				Expect(report.Filter()).To(BeEquivalentTo(report))
+				Expect(report.Filter(p)).To(BeEquivalentTo(Report{Diffs: []Diff{
+					singleDiff(pathString, ADDITION, nil, "foobar"),
+				}}))
+
+				Expect(report.Filter(path("/does/not/exist"))).To(BeEquivalentTo(Report{}))
+			})
 		})
 
 		Context("change root for comparison", func() {

--- a/pkg/dyff/models.go
+++ b/pkg/dyff/models.go
@@ -59,6 +59,27 @@ type Report struct {
 	Diffs []Diff
 }
 
+func (r Report) Filter(paths ...ytbx.Path) (result Report) {
+	if len(paths) == 0 {
+		return r
+	}
+
+	result = Report{
+		From: r.From,
+		To:   r.To,
+	}
+
+	for _, diff := range r.Diffs {
+		for _, path := range paths {
+			if diff.Path.String() == path.String() {
+				result.Diffs = append(result.Diffs, diff)
+			}
+		}
+	}
+
+	return result
+}
+
 // ReportWriter defines the interface required for types that can write reports
 type ReportWriter interface {
 	WriteReport(out io.Writer) error

--- a/pkg/dyff/models.go
+++ b/pkg/dyff/models.go
@@ -59,27 +59,6 @@ type Report struct {
 	Diffs []Diff
 }
 
-func (r Report) Filter(paths ...ytbx.Path) (result Report) {
-	if len(paths) == 0 {
-		return r
-	}
-
-	result = Report{
-		From: r.From,
-		To:   r.To,
-	}
-
-	for _, diff := range r.Diffs {
-		for _, path := range paths {
-			if diff.Path.String() == path.String() {
-				result.Diffs = append(result.Diffs, diff)
-			}
-		}
-	}
-
-	return result
-}
-
 // ReportWriter defines the interface required for types that can write reports
 type ReportWriter interface {
 	WriteReport(out io.Writer) error

--- a/pkg/dyff/reports.go
+++ b/pkg/dyff/reports.go
@@ -1,0 +1,30 @@
+package dyff
+
+import "github.com/gonvenience/ytbx"
+
+// Filter accepts YAML paths as input and returns a new report with differences for those paths only
+func (r Report) Filter(paths ...ytbx.Path) (result Report) {
+	if len(paths) == 0 {
+		return r
+	}
+
+	result = Report{
+		From: r.From,
+		To:   r.To,
+	}
+
+	pathsMap := make(map[string]struct{})
+
+	for _, path := range paths {
+		pathsMap[path.String()] = struct{}{}
+	}
+
+	for _, diff := range r.Diffs {
+		diffPathString := diff.Path.String()
+		if _, ok := pathsMap[diffPathString]; ok {
+			result.Diffs = append(result.Diffs, diff)
+		}
+	}
+
+	return result
+}


### PR DESCRIPTION
Reports can be filtered on set of paths

Fixes issue #157 

User wants to focus on specific differences and therefore wants to filter on
paths in the report. All the others should be omitted.
  
Add `Filter` function to Report to filter on paths.

Add flag for provinding filtering arguments.

Add `reports.go` for methods of `Report` structure