### PR TITLE
Fix format specifier missing errors in strings in tables and missing objects during order change

### DIFF
--- a/pkg/dyff/output_human.go
+++ b/pkg/dyff/output_human.go
@@ -299,8 +299,8 @@ func (report *HumanReport) generateHumanDetailOutputOrderchange(detail Detail) (
 
 		} else {
 			output.WriteString(CreateTableStyleString(" ", 2,
-				red(strings.Join(from, "\n")),
-				green(strings.Join(to, "\n"))))
+				red("%s", strings.Join(from, "\n")),
+				green("%s", strings.Join(to, "\n"))))
 		}
 	}
 
@@ -361,8 +361,8 @@ func (report *HumanReport) highlightByLine(from, to string) string {
 
 	} else {
 		report.writeTextBlocks(&buf, 0,
-			red(createStringWithPrefix("  - ", from)),
-			green(createStringWithPrefix("  + ", to)),
+			red("%s", createStringWithPrefix("  - ", from)),
+			green("%s", createStringWithPrefix("  + ", to)),
 		)
 	}
 

--- a/pkg/dyff/output_human.go
+++ b/pkg/dyff/output_human.go
@@ -277,17 +277,31 @@ func (report *HumanReport) generateHumanDetailOutputOrderchange(detail Detail) (
 	output.WriteString(yellow(fmt.Sprintf("%c order changed\n", ORDERCHANGE)))
 	switch detail.From.Kind {
 	case yamlv3.SequenceNode:
-		asStringList := func(sequenceNode *yamlv3.Node) []string {
+		asStringList := func(sequenceNode *yamlv3.Node) ([]string, error) {
 			result := make([]string, len(sequenceNode.Content))
 			for i, entry := range sequenceNode.Content {
 				result[i] = entry.Value
+				if entry.Value == "" {
+					s, err := yamlString(entry)
+					if err != nil {
+						return result, err
+					}
+					result[i] = s
+				}
 			}
 
-			return result
+			return result, nil
 		}
 
-		from := asStringList(detail.From)
-		to := asStringList(detail.To)
+		from, err := asStringList(detail.From)
+		if err != nil {
+			return "", err
+		}
+		to, err := asStringList(detail.To)
+		if err != nil {
+			return "", err
+		}
+
 		const singleLineSeparator = ", "
 
 		threshold := term.GetTerminalWidth() / 2


### PR DESCRIPTION
Hey appreciate all the awesome work that's been done on dyff, really getting some great use out of it.

I ran into two little issues however that I wanted to address:
- The first is that strings that have format specifiers in them get corrupted in the table style strings, i.e. `cool-string%s` displays as `cool-string%!s(MISSING)`, I think that just not using the string that needs to be colorized as the format string is sufficient, but I might be missing an edge case.
- The second is that reordering of more complicated nested object don't really show any output besides something like
  ```
    ⇆ order changed
    - ,
    + ,
    ```
I think it's because the nodes in question are not terminal and therefore don't have string values. I borrowed the yamlString method to account for those cases.

Let me know if there's anything else I should add to this PR or if there's any edge cases I might not have accounted for, happy to make adjustments 👍 