### PR TITLE
Clarify `kubectl diff` usage (#158)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ GO111MODULE=on go get github.com/homeport/dyff/cmd/dyff
 
 ## Use cases and examples
 
-- Show differences between the live configuration of Kubernetes resources and what would be applied:
+- Show differences between the live configuration of Kubernetes resources and what would be applied (`kubectl` version >= `v1.20.0`):
 
   ```bash
   # Setup
@@ -69,6 +69,8 @@ GO111MODULE=on go get github.com/homeport/dyff/cmd/dyff
   ![dyff between example with kubectl diff](.docs/dyff-between-kubectl-diff.png?raw=true "dyff in kubectl diff example")
 
   The `--set-exit-code` flag is required so that the `dyff` exit code matches `kubectl` expectations. An exit code `0` refers to no differences, `1` in case differences are detected. Other exit codes are treated as program issues.
+  
+  _Note:_ Versions of `kubectl` older than `v1.20.0` did not split the environment variable into field, therefore you cannot use command arguments. In this case, you need to wrap the `dyff` command with its argument into a helper shell script and use this instead.
 
 - Show the differences between two versions of [`cf-deployment`](https://github.com/cloudfoundry/cf-deployment/) YAMLs:
 


### PR DESCRIPTION
Fixes #158

References https://github.com/kubernetes/kubectl/issues/937, https://github.com/kubernetes/kubectl/commit/bafd13fd9fe4c980c250ec865310ebc31622b745

Add minimum version required.

Explain workaround for older `kubectl` versions.