### PR TITLE
Add `system-files` plug

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,4 +68,8 @@ snapcrafts:
   base: bare
   apps:
     dyff:
-      plugs: ["home", "network"]
+      plugs: ["home", "network", "system-files"]
+  plugs:
+    system-files:
+      read:
+      - /tmp


### PR DESCRIPTION
Fixes #194 (hopefully)

Add `system-files` plug to snapcrafts section with read-only access to `/tmp`.