### PR TITLE
Switch to `classic` confinement

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,13 +63,9 @@ snapcrafts:
   summary: "YAML diff tool"
   description: "δyƒƒ /ˈdʏf/ - A diff tool for YAML files, and sometimes JSON"
   grade: stable
-  confinement: strict
+  confinement: classic
   license: MIT
   base: bare
   apps:
     dyff:
-      plugs: ["home", "network", "system-files"]
-  plugs:
-    system-files:
-      read:
-      - /tmp
+      plugs: ["home", "network"]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ sudo port install dyff
 It is [available in the `snapcraft` store](https://snapcraft.io/dyff) in the Productivity section.
 
 ```bash
-snap install dyff
+snap install --classic dyff
 ```
 
 ### Pre-built binaries in GitHub


### PR DESCRIPTION
Since input files could be stored everywhere in the system, i.e. `/tmp`, the
confinement mode `strict` is not very helpful.

Switch to `classic` confinement.
