### PR TITLE
Add exclude option & filter or exclude by regular expression

### DIFF
--- a/internal/cmd/between.go
+++ b/internal/cmd/between.go
@@ -95,8 +95,16 @@ types are: YAML (http://yaml.org/) and JSON (http://json.org/).
 			report = report.Filter(reportOptions.filters...)
 		}
 
+		if reportOptions.filterRegexps != nil {
+			report = report.FilterRegexp(reportOptions.filterRegexps...)
+		}
+
 		if reportOptions.excludes != nil {
 			report = report.Exclude(reportOptions.excludes...)
+		}
+
+		if reportOptions.excludeRegexps != nil {
+			report = report.ExcludeRegexp(reportOptions.excludeRegexps...)
 		}
 
 		return writeReport(cmd, report)

--- a/internal/cmd/between.go
+++ b/internal/cmd/between.go
@@ -92,17 +92,11 @@ types are: YAML (http://yaml.org/) and JSON (http://json.org/).
 		}
 
 		if reportOptions.filters != nil {
-			var filterPaths []*ytbx.Path
-			for _, pathString := range reportOptions.filters {
-				path, err := ytbx.ParsePathStringUnsafe(pathString)
-				if err != nil {
-					return wrap.Errorf(err, "failed to set path filter, because path %s cannot be parsed", pathString)
-				}
+			report = report.Filter(reportOptions.filters...)
+		}
 
-				filterPaths = append(filterPaths, &path)
-			}
-
-			report = report.Filter(filterPaths...)
+		if reportOptions.excludes != nil {
+			report = report.Exclude(reportOptions.excludes...)
 		}
 
 		return writeReport(cmd, report)

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -51,6 +51,7 @@ type reportConfig struct {
 	omitHeader                bool
 	useGoPatchPaths           bool
 	filters                   []string
+	excludes                  []string
 }
 
 var reportOptions reportConfig
@@ -60,6 +61,7 @@ func applyReportOptionsFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&reportOptions.ignoreOrderChanges, "ignore-order-changes", "i", false, "ignore order changes in lists")
 	cmd.Flags().BoolVarP(&reportOptions.kubernetesEntityDetection, "detect-kubernetes", "", true, "detect kubernetes entities")
 	cmd.Flags().StringSliceVar(&reportOptions.filters, "filter", nil, "filter reports to a subset of differences based on supplied arguments")
+	cmd.Flags().StringSliceVar(&reportOptions.excludes, "exclude", nil, "exclude reports to a subset of differences based on supplied arguments")
 
 	// Main output preferences
 	cmd.Flags().StringVarP(&reportOptions.style, "output", "o", defaultOutputStyle, "specify the output style, supported styles: human, or brief")

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -52,6 +52,8 @@ type reportConfig struct {
 	useGoPatchPaths           bool
 	filters                   []string
 	excludes                  []string
+	filterRegexps             []string
+	excludeRegexps            []string
 }
 
 var reportOptions reportConfig
@@ -62,6 +64,8 @@ func applyReportOptionsFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&reportOptions.kubernetesEntityDetection, "detect-kubernetes", "", true, "detect kubernetes entities")
 	cmd.Flags().StringSliceVar(&reportOptions.filters, "filter", nil, "filter reports to a subset of differences based on supplied arguments")
 	cmd.Flags().StringSliceVar(&reportOptions.excludes, "exclude", nil, "exclude reports to a subset of differences based on supplied arguments")
+	cmd.Flags().StringSliceVar(&reportOptions.filterRegexps, "filter-regexp", nil, "filter reports to a subset of differences based on supplied regular expressions")
+	cmd.Flags().StringSliceVar(&reportOptions.excludeRegexps, "exclude-regexp", nil, "exclude reports to a subset of differences based on supplied regular expressions")
 
 	// Main output preferences
 	cmd.Flags().StringVarP(&reportOptions.style, "output", "o", defaultOutputStyle, "specify the output style, supported styles: human, or brief")

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -63,9 +63,9 @@ func applyReportOptionsFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&reportOptions.ignoreOrderChanges, "ignore-order-changes", "i", false, "ignore order changes in lists")
 	cmd.Flags().BoolVarP(&reportOptions.kubernetesEntityDetection, "detect-kubernetes", "", true, "detect kubernetes entities")
 	cmd.Flags().StringSliceVar(&reportOptions.filters, "filter", nil, "filter reports to a subset of differences based on supplied arguments")
-	cmd.Flags().StringSliceVar(&reportOptions.excludes, "exclude", nil, "exclude reports to a subset of differences based on supplied arguments")
+	cmd.Flags().StringSliceVar(&reportOptions.excludes, "exclude", nil, "exclude reports from a set of differences based on supplied arguments")
 	cmd.Flags().StringSliceVar(&reportOptions.filterRegexps, "filter-regexp", nil, "filter reports to a subset of differences based on supplied regular expressions")
-	cmd.Flags().StringSliceVar(&reportOptions.excludeRegexps, "exclude-regexp", nil, "exclude reports to a subset of differences based on supplied regular expressions")
+	cmd.Flags().StringSliceVar(&reportOptions.excludeRegexps, "exclude-regexp", nil, "exclude reports from a set of differences based on supplied regular expressions")
 
 	// Main output preferences
 	cmd.Flags().StringVarP(&reportOptions.style, "output", "o", defaultOutputStyle, "specify the output style, supported styles: human, or brief")

--- a/pkg/dyff/compare_test.go
+++ b/pkg/dyff/compare_test.go
@@ -757,12 +757,12 @@ listY: [ Yo, Yo, Yo ]
 					singleDiff("/yaml/map/barfoo", ADDITION, nil, "barfoo"),
 				}}
 
-				Expect(report.Filter()).To(BeEquivalentTo(report))
-				Expect(report.Filter("foobar")).To(BeEquivalentTo(Report{Diffs: []Diff{
+				Expect(report.FilterRegexp()).To(BeEquivalentTo(report))
+				Expect(report.FilterRegexp("foobar")).To(BeEquivalentTo(Report{Diffs: []Diff{
 					singleDiff(pathString, ADDITION, nil, "foobar"),
 				}}))
 
-				Expect(report.Filter("/does/not/exist")).To(BeEquivalentTo(Report{}))
+				Expect(report.FilterRegexp("/does/not/exist")).To(BeEquivalentTo(Report{}))
 			})
 
 			It("should exclude my report based on regular expressions", func() {
@@ -773,12 +773,12 @@ listY: [ Yo, Yo, Yo ]
 					singleDiff("/yaml/map/barfoo", ADDITION, nil, "barfoo"),
 				}}
 
-				Expect(report.Exclude()).To(BeEquivalentTo(report))
-				Expect(report.Exclude("barfoo")).To(BeEquivalentTo(Report{Diffs: []Diff{
+				Expect(report.ExcludeRegexp()).To(BeEquivalentTo(report))
+				Expect(report.ExcludeRegexp("barfoo")).To(BeEquivalentTo(Report{Diffs: []Diff{
 					singleDiff(pathString, ADDITION, nil, "foobar"),
 				}}))
 
-				Expect(report.Exclude("/does/not/exist")).To(BeEquivalentTo(report))
+				Expect(report.ExcludeRegexp("/does/not/exist")).To(BeEquivalentTo(report))
 			})
 		})
 

--- a/pkg/dyff/compare_test.go
+++ b/pkg/dyff/compare_test.go
@@ -735,7 +735,6 @@ listY: [ Yo, Yo, Yo ]
 
 			It("should filter my report based on set of paths", func() {
 				pathString := "/yaml/map/foobar"
-				p := path(pathString)
 
 				report := Report{Diffs: []Diff{
 					singleDiff(pathString, ADDITION, nil, "foobar"),
@@ -743,11 +742,43 @@ listY: [ Yo, Yo, Yo ]
 				}}
 
 				Expect(report.Filter()).To(BeEquivalentTo(report))
-				Expect(report.Filter(p)).To(BeEquivalentTo(Report{Diffs: []Diff{
+				Expect(report.Filter(pathString)).To(BeEquivalentTo(Report{Diffs: []Diff{
 					singleDiff(pathString, ADDITION, nil, "foobar"),
 				}}))
 
-				Expect(report.Filter(path("/does/not/exist"))).To(BeEquivalentTo(Report{}))
+				Expect(report.Filter("/does/not/exist")).To(BeEquivalentTo(Report{}))
+			})
+
+			It("should filter my report based on set of regular expressions", func() {
+				pathString := "/yaml/map/foobar"
+
+				report := Report{Diffs: []Diff{
+					singleDiff(pathString, ADDITION, nil, "foobar"),
+					singleDiff("/yaml/map/barfoo", ADDITION, nil, "barfoo"),
+				}}
+
+				Expect(report.Filter()).To(BeEquivalentTo(report))
+				Expect(report.Filter("foobar")).To(BeEquivalentTo(Report{Diffs: []Diff{
+					singleDiff(pathString, ADDITION, nil, "foobar"),
+				}}))
+
+				Expect(report.Filter("/does/not/exist")).To(BeEquivalentTo(Report{}))
+			})
+
+			It("should exclude my report based on regular expressions", func() {
+				pathString := "/yaml/map/foobar"
+
+				report := Report{Diffs: []Diff{
+					singleDiff(pathString, ADDITION, nil, "foobar"),
+					singleDiff("/yaml/map/barfoo", ADDITION, nil, "barfoo"),
+				}}
+
+				Expect(report.Exclude()).To(BeEquivalentTo(report))
+				Expect(report.Exclude("barfoo")).To(BeEquivalentTo(Report{Diffs: []Diff{
+					singleDiff(pathString, ADDITION, nil, "foobar"),
+				}}))
+
+				Expect(report.Exclude("/does/not/exist")).To(BeEquivalentTo(report))
 			})
 		})
 

--- a/pkg/dyff/reports.go
+++ b/pkg/dyff/reports.go
@@ -50,7 +50,7 @@ func (r Report) Exclude(paths ...string) (result Report) {
 	})
 }
 
-// FilterRegexp accepts YAML paths as input and returns a new report with differences without those paths
+// FilterRegexp accepts regular expressions as input and returns a new report with differences for matching those patterns
 func (r Report) FilterRegexp(pattern ...string) (result Report) {
 	if len(pattern) == 0 {
 		return r
@@ -71,7 +71,7 @@ func (r Report) FilterRegexp(pattern ...string) (result Report) {
 	})
 }
 
-// ExcludeRegexp accepts YAML paths as input and returns a new report with differences without those paths
+// ExcludeRegexp accepts regular expressions as input and returns a new report with differences for not matching those patterns
 func (r Report) ExcludeRegexp(pattern ...string) (result Report) {
 	if len(pattern) == 0 {
 		return r

--- a/pkg/dyff/reports.go
+++ b/pkg/dyff/reports.go
@@ -24,14 +24,9 @@ func (r Report) Filter(paths ...string) (result Report) {
 		return r
 	}
 
-	regexps := make([]*regexp.Regexp, len(paths))
-	for i := range paths {
-		regexps[i] = regexp.MustCompile(paths[i])
-	}
-
 	return r.filter(func(s string) bool {
-		for _, regexp := range regexps {
-			if regexp.MatchString(s) {
+		for _, path := range paths {
+			if path == s {
 				return true
 			}
 		}
@@ -45,9 +40,46 @@ func (r Report) Exclude(paths ...string) (result Report) {
 		return r
 	}
 
-	regexps := make([]*regexp.Regexp, len(paths))
-	for i := range paths {
-		regexps[i] = regexp.MustCompile(paths[i])
+	return r.filter(func(s string) bool {
+		for _, path := range paths {
+			if path == s {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+// FilterRegexp accepts YAML paths as input and returns a new report with differences without those paths
+func (r Report) FilterRegexp(pattern ...string) (result Report) {
+	if len(pattern) == 0 {
+		return r
+	}
+
+	regexps := make([]*regexp.Regexp, len(pattern))
+	for i := range pattern {
+		regexps[i] = regexp.MustCompile(pattern[i])
+	}
+
+	return r.filter(func(s string) bool {
+		for _, regexp := range regexps {
+			if regexp.MatchString(s) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// ExcludeRegexp accepts YAML paths as input and returns a new report with differences without those paths
+func (r Report) ExcludeRegexp(pattern ...string) (result Report) {
+	if len(pattern) == 0 {
+		return r
+	}
+
+	regexps := make([]*regexp.Regexp, len(pattern))
+	for i := range pattern {
+		regexps[i] = regexp.MustCompile(pattern[i])
 	}
 
 	return r.filter(func(s string) bool {

--- a/pkg/dyff/reports.go
+++ b/pkg/dyff/reports.go
@@ -1,9 +1,9 @@
 package dyff
 
-import "github.com/gonvenience/ytbx"
+import "regexp"
 
 // Filter accepts YAML paths as input and returns a new report with differences for those paths only
-func (r Report) Filter(paths ...*ytbx.Path) (result Report) {
+func (r Report) Filter(paths ...string) (result Report) {
 	if len(paths) == 0 {
 		return r
 	}
@@ -13,15 +13,51 @@ func (r Report) Filter(paths ...*ytbx.Path) (result Report) {
 		To:   r.To,
 	}
 
-	pathsMap := make(map[string]struct{})
-
-	for _, path := range paths {
-		pathsMap[path.String()] = struct{}{}
+	regexps := make([]*regexp.Regexp, len(paths))
+	for i := range paths {
+		regexps[i] = regexp.MustCompile(paths[i])
 	}
 
 	for _, diff := range r.Diffs {
 		diffPathString := diff.Path.String()
-		if _, ok := pathsMap[diffPathString]; ok {
+		for _, regexp := range regexps {
+			if regexp.MatchString(diffPathString) {
+				result.Diffs = append(result.Diffs, diff)
+				break
+			}
+		}
+	}
+
+	return result
+}
+
+// Exclude accepts YAML paths as input and returns a new report with differences without those paths
+func (r Report) Exclude(paths ...string) (result Report) {
+	if len(paths) == 0 {
+		return r
+	}
+
+	result = Report{
+		From: r.From,
+		To:   r.To,
+	}
+
+	regexps := make([]*regexp.Regexp, len(paths))
+	for i := range paths {
+		regexps[i] = regexp.MustCompile(paths[i])
+	}
+
+	for _, diff := range r.Diffs {
+		diffPathString := diff.Path.String()
+		var any bool
+		for _, regexp := range regexps {
+			if regexp.MatchString(diffPathString) {
+				any = true
+				break
+			}
+		}
+
+		if !any {
 			result.Diffs = append(result.Diffs, diff)
 		}
 	}


### PR DESCRIPTION
Fix https://github.com/homeport/dyff/issues/173

I've added three options to `between` subcommand.
This feature is useful when you have a lot of things you want to filter or exclude.

* `--exclude`
  * exclude reports from a set of differences based on supplied arguments
* `--filter-regexp`
  * filter reports to a subset of differences based on supplied regular expressions
* `--exclude-regexp`
  * exclude reports from a set of differences based on supplied regular expressions