### PR TITLE
Ignore exclude/filter action if filterPath given is nil

### DIFF
--- a/assets/issues/issue-232/from.yml
+++ b/assets/issues/issue-232/from.yml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    test: label1
+    app: test
+  name: test
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - image: k8s.gcr.io/serve_hostname
+        imagePullPolicy: Always
+        name: test

--- a/assets/issues/issue-232/to.yml
+++ b/assets/issues/issue-232/to.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    test: label2
+    app: test
+  name: test
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - image: k8s.gcr.io/serve_hostname
+        imagePullPolicy: Always
+        name: test

--- a/internal/cmd/cmds_test.go
+++ b/internal/cmd/cmds_test.go
@@ -533,6 +533,22 @@ yaml.map.whitespaces
 			})
 		})
 
+		It("should show a report when filtering and a document has been removed between inputs", func() {
+			expected := `
+spec.replicas  (Deployment/default/test)
+  ± value change
+    - 2
+    + 3
+
+
+`
+			By("using the --filter flag", func() {
+				out, err := dyff("between", "--omit-header", "--filter", "/spec/replicas", assets("issues", "issue-232", "from.yml"), assets("issues", "issue-232", "to.yml"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).To(BeEquivalentTo(expected))
+			})
+		})
+
 		It("should properly print multi-line strings (https://github.com/homeport/dyff/issues/180)", func() {
 			out, err := dyff("between", "--omit-header", assets("issues", "issue-180", "old.yml"), assets("issues", "issue-180", "new.yml"))
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/dyff/reports.go
+++ b/pkg/dyff/reports.go
@@ -30,7 +30,7 @@ func (r Report) Filter(paths ...string) (result Report) {
 	return r.filter(func(filterPath *ytbx.Path) bool {
 		for _, pathString := range paths {
 			path, err := ytbx.ParsePathStringUnsafe(pathString)
-			if err == nil && path.String() == filterPath.String() {
+			if err == nil && filterPath != nil && path.String() == filterPath.String() {
 				return true
 			}
 		}
@@ -48,7 +48,7 @@ func (r Report) Exclude(paths ...string) (result Report) {
 	return r.filter(func(filterPath *ytbx.Path) bool {
 		for _, pathString := range paths {
 			path, err := ytbx.ParsePathStringUnsafe(pathString)
-			if err == nil && path.String() == filterPath.String() {
+			if err == nil && filterPath != nil && path.String() == filterPath.String() {
 				return false
 			}
 		}
@@ -70,7 +70,7 @@ func (r Report) FilterRegexp(pattern ...string) (result Report) {
 
 	return r.filter(func(filterPath *ytbx.Path) bool {
 		for _, regexp := range regexps {
-			if regexp.MatchString(filterPath.String()) {
+			if filterPath != nil && regexp.MatchString(filterPath.String()) {
 				return true
 			}
 		}
@@ -91,7 +91,7 @@ func (r Report) ExcludeRegexp(pattern ...string) (result Report) {
 
 	return r.filter(func(filterPath *ytbx.Path) bool {
 		for _, regexp := range regexps {
-			if regexp.MatchString(filterPath.String()) {
+			if filterPath != nil && regexp.MatchString(filterPath.String()) {
 				return false
 			}
 		}


### PR DESCRIPTION
This hopefully solves [issue 232](https://github.com/homeport/dyff/issues/232). When comparing two YAMLs with a document removed and using the `--exclude` flag I noticed that dyff threw a panic. I think this is because those `Diff` objects don't have a `Path` set (must be `nil`) so when we do `--exclude` (or any of the other exclude/filter flags) it will panic trying to produce the report. Let me know if there is anything else you'd like me to do :) 