### PR TITLE
Fix panic when using `--exclude` on reports with documents removed

### DIFF
--- a/assets/issues/issue-232/from.yml
+++ b/assets/issues/issue-232/from.yml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    test: label1
+    app: test
+  name: test
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - image: k8s.gcr.io/serve_hostname
+        imagePullPolicy: Always
+        name: test

--- a/assets/issues/issue-232/to.yml
+++ b/assets/issues/issue-232/to.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    test: label2
+    app: test
+  name: test
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - image: k8s.gcr.io/serve_hostname
+        imagePullPolicy: Always
+        name: test

--- a/internal/cmd/cmds_test.go
+++ b/internal/cmd/cmds_test.go
@@ -533,6 +533,22 @@ yaml.map.whitespaces
 			})
 		})
 
+		It("should show a report when filtering and a document has been removed between inputs", func() {
+			expected := `
+spec.replicas  (Deployment/default/test)
+  ± value change
+    - 2
+    + 3
+
+
+`
+			By("using the --filter flag", func() {
+				out, err := dyff("between", "--omit-header", "--filter", "/spec/replicas", assets("issues", "issue-232", "from.yml"), assets("issues", "issue-232", "to.yml"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).To(BeEquivalentTo(expected))
+			})
+		})
+
 		It("should properly print multi-line strings (https://github.com/homeport/dyff/issues/180)", func() {
 			out, err := dyff("between", "--omit-header", assets("issues", "issue-180", "old.yml"), assets("issues", "issue-180", "new.yml"))
 			Expect(err).ToNot(HaveOccurred())

--- a/internal/cmd/cmds_test.go
+++ b/internal/cmd/cmds_test.go
@@ -540,7 +540,6 @@ spec.replicas  (Deployment/default/test)
     - 2
     + 3
 
-
 `
 			By("using the --filter flag", func() {
 				out, err := dyff("between", "--omit-header", "--filter", "/spec/replicas", assets("issues", "issue-232", "from.yml"), assets("issues", "issue-232", "to.yml"))

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -39,8 +39,6 @@ import (
 	"github.com/homeport/dyff/pkg/dyff"
 )
 
-const defaultOutputStyle = "human"
-
 type reportConfig struct {
 	style                     string
 	ignoreOrderChanges        bool
@@ -56,29 +54,44 @@ type reportConfig struct {
 	excludeRegexps            []string
 }
 
+var defaults = reportConfig{
+	style:                     "human",
+	ignoreOrderChanges:        false,
+	kubernetesEntityDetection: true,
+	noTableStyle:              false,
+	doNotInspectCerts:         false,
+	exitWithCode:              false,
+	omitHeader:                false,
+	useGoPatchPaths:           false,
+	filters:                   nil,
+	excludes:                  nil,
+	filterRegexps:             nil,
+	excludeRegexps:            nil,
+}
+
 var reportOptions reportConfig
 
 func applyReportOptionsFlags(cmd *cobra.Command) {
 	// Compare options
-	cmd.Flags().BoolVarP(&reportOptions.ignoreOrderChanges, "ignore-order-changes", "i", false, "ignore order changes in lists")
-	cmd.Flags().BoolVarP(&reportOptions.kubernetesEntityDetection, "detect-kubernetes", "", true, "detect kubernetes entities")
-	cmd.Flags().StringSliceVar(&reportOptions.filters, "filter", nil, "filter reports to a subset of differences based on supplied arguments")
-	cmd.Flags().StringSliceVar(&reportOptions.excludes, "exclude", nil, "exclude reports from a set of differences based on supplied arguments")
-	cmd.Flags().StringSliceVar(&reportOptions.filterRegexps, "filter-regexp", nil, "filter reports to a subset of differences based on supplied regular expressions")
-	cmd.Flags().StringSliceVar(&reportOptions.excludeRegexps, "exclude-regexp", nil, "exclude reports from a set of differences based on supplied regular expressions")
+	cmd.Flags().BoolVarP(&reportOptions.ignoreOrderChanges, "ignore-order-changes", "i", defaults.ignoreOrderChanges, "ignore order changes in lists")
+	cmd.Flags().BoolVarP(&reportOptions.kubernetesEntityDetection, "detect-kubernetes", "", defaults.kubernetesEntityDetection, "detect kubernetes entities")
+	cmd.Flags().StringSliceVar(&reportOptions.filters, "filter", defaults.filters, "filter reports to a subset of differences based on supplied arguments")
+	cmd.Flags().StringSliceVar(&reportOptions.excludes, "exclude", defaults.excludes, "exclude reports from a set of differences based on supplied arguments")
+	cmd.Flags().StringSliceVar(&reportOptions.filterRegexps, "filter-regexp", defaults.filterRegexps, "filter reports to a subset of differences based on supplied regular expressions")
+	cmd.Flags().StringSliceVar(&reportOptions.excludeRegexps, "exclude-regexp", defaults.excludeRegexps, "exclude reports from a set of differences based on supplied regular expressions")
 
 	// Main output preferences
-	cmd.Flags().StringVarP(&reportOptions.style, "output", "o", defaultOutputStyle, "specify the output style, supported styles: human, or brief")
-	cmd.Flags().BoolVarP(&reportOptions.omitHeader, "omit-header", "b", false, "omit the dyff summary header")
-	cmd.Flags().BoolVarP(&reportOptions.exitWithCode, "set-exit-code", "s", false, "set program exit code, with 0 meaning no difference, 1 for differences detected, and 255 for program error")
+	cmd.Flags().StringVarP(&reportOptions.style, "output", "o", defaults.style, "specify the output style, supported styles: human, or brief")
+	cmd.Flags().BoolVarP(&reportOptions.omitHeader, "omit-header", "b", defaults.omitHeader, "omit the dyff summary header")
+	cmd.Flags().BoolVarP(&reportOptions.exitWithCode, "set-exit-code", "s", defaults.exitWithCode, "set program exit code, with 0 meaning no difference, 1 for differences detected, and 255 for program error")
 
 	// Human/BOSH output related flags
-	cmd.Flags().BoolVarP(&reportOptions.noTableStyle, "no-table-style", "l", false, "do not place blocks next to each other, always use one row per text block")
-	cmd.Flags().BoolVarP(&reportOptions.doNotInspectCerts, "no-cert-inspection", "x", false, "disable x509 certificate inspection, compare as raw text")
-	cmd.Flags().BoolVarP(&reportOptions.useGoPatchPaths, "use-go-patch-style", "g", false, "use Go-Patch style paths in outputs")
+	cmd.Flags().BoolVarP(&reportOptions.noTableStyle, "no-table-style", "l", defaults.noTableStyle, "do not place blocks next to each other, always use one row per text block")
+	cmd.Flags().BoolVarP(&reportOptions.doNotInspectCerts, "no-cert-inspection", "x", defaults.doNotInspectCerts, "disable x509 certificate inspection, compare as raw text")
+	cmd.Flags().BoolVarP(&reportOptions.useGoPatchPaths, "use-go-patch-style", "g", defaults.useGoPatchPaths, "use Go-Patch style paths in outputs")
 
 	// Deprecated
-	cmd.Flags().BoolVar(&reportOptions.exitWithCode, "set-exit-status", false, "set program exit code, with 0 meaning no difference, 1 for differences detected, and 255 for program error")
+	cmd.Flags().BoolVar(&reportOptions.exitWithCode, "set-exit-status", defaults.exitWithCode, "set program exit code, with 0 meaning no difference, 1 for differences detected, and 255 for program error")
 	_ = cmd.Flags().MarkDeprecated("set-exit-status", "use --set-exit-code instead")
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -69,7 +69,7 @@ is preserved during the conversion.
 // ResetSettings resets command settings to default. This is only required by
 // the test suite to make sure that the flag parsing works correctly.
 func ResetSettings() {
-	reportOptions = reportConfig{style: defaultOutputStyle}
+	reportOptions = defaults
 	betweenCmdSettings = betweenCmdOptions{}
 	yamlCmdSettings = yamlCmdOptions{}
 	jsonCmdSettings = jsonCmdOptions{}

--- a/pkg/dyff/reports.go
+++ b/pkg/dyff/reports.go
@@ -30,7 +30,7 @@ func (r Report) Filter(paths ...string) (result Report) {
 	return r.filter(func(filterPath *ytbx.Path) bool {
 		for _, pathString := range paths {
 			path, err := ytbx.ParsePathStringUnsafe(pathString)
-			if err == nil && path.String() == filterPath.String() {
+			if err == nil && filterPath != nil && path.String() == filterPath.String() {
 				return true
 			}
 		}
@@ -48,7 +48,7 @@ func (r Report) Exclude(paths ...string) (result Report) {
 	return r.filter(func(filterPath *ytbx.Path) bool {
 		for _, pathString := range paths {
 			path, err := ytbx.ParsePathStringUnsafe(pathString)
-			if err == nil && path.String() == filterPath.String() {
+			if err == nil && filterPath != nil && path.String() == filterPath.String() {
 				return false
 			}
 		}
@@ -70,7 +70,7 @@ func (r Report) FilterRegexp(pattern ...string) (result Report) {
 
 	return r.filter(func(filterPath *ytbx.Path) bool {
 		for _, regexp := range regexps {
-			if regexp.MatchString(filterPath.String()) {
+			if filterPath != nil && regexp.MatchString(filterPath.String()) {
 				return true
 			}
 		}
@@ -91,7 +91,7 @@ func (r Report) ExcludeRegexp(pattern ...string) (result Report) {
 
 	return r.filter(func(filterPath *ytbx.Path) bool {
 		for _, regexp := range regexps {
-			if regexp.MatchString(filterPath.String()) {
+			if filterPath != nil && regexp.MatchString(filterPath.String()) {
 				return false
 			}
 		}


### PR DESCRIPTION
Follow-up from PR #233

Combined commits from PR #233 to fix #232 as well as an internal fix to a inconsistency of the tool defaults, which differed between using `dyff` as a standalone binary versus using its core logic in a test case.