### PR TITLE
Enable the addition of custom identifier keys

### DIFF
--- a/assets/issues/issue-243/from.yml
+++ b/assets/issues/issue-243/from.yml
@@ -1,0 +1,112 @@
+cicd:
+    artifacts:
+        keepartifacts: true
+    generalpipelines:
+        autocancelredundantpipelines: enabled
+        buildcoverageregex: ""
+        buildtimeout: 3600
+        gitstrategy: fetch
+        publicpipelines: false
+    runners: []
+    variables: []
+general:
+    mergerequestapprovals:
+        approvalrules:
+            - groups:
+                - developers
+              name: Git Approvers
+              required: 1
+              targetbranch: []
+              users: []
+        disableoverridingapproverspermergerequest: true
+        mergerequestsauthorapproval: false
+        mergerequestsdisablecommittersapproval: false
+        requirepasswordtoapprove: false
+        resetapprovalsonpush: false
+    mergerequests:
+        allowmergeonskippedpipeline: false
+        mergecommittemplate: ""
+        mergemethod: ff
+        mergepipelinesenabled: true
+        mergerequestsenabled: true
+        mergetrainsenabled: false
+        onlyallowmergeifalldiscussionsareresolved: true
+        onlyallowmergeifpipelinesucceeds: true
+        printingmergerequestlinkenabled: true
+        removesourcebranchaftermerge: true
+        resolveoutdateddiffdiscussions: true
+        squashcommittemplate: ""
+        squashoption: default_on
+    visibility:
+        analyticsaccesslevel: enabled
+        issuesaccesslevel: disabled
+        mergerequestsaccesslevel: enabled
+        public: false
+        requestaccessenabled: false
+        securityandcomplianceaccesslevel: private
+        snippetsaccesslevel: disabled
+        visibility: internal
+        wikiaccesslevel: disabled
+info:
+    members:
+        groups:
+            - id: 41865
+              maxrole: 40
+              name: maintainers
+            - id: 41866
+              maxrole: 30
+              name: approvers
+            - id: 16951
+              maxrole: 30
+              name: developers
+            - id: 3857
+              maxrole: 30
+              name: all
+        users:
+            - id: 12141
+              maxrole: 20
+              name: User2
+            - id: 552
+              maxrole: 40
+              name: User1
+            - id: 13509
+              maxrole: 30
+              name: User3
+project_id: 66800
+repository:
+    defaultbranch:
+        autoclosereferencedissues: true
+        defaultbranch: main
+    protectedbranches:
+        - allowedtoforcepush: false
+          allowedtomerge:
+            - level: 40
+              name: developers
+          allowedtopush:
+            - level: 0
+              name: No one
+            - level: 40
+              name: Build Systems
+          branch: main
+          codeownerapproval: true
+        - allowedtoforcepush: false
+          allowedtomerge:
+            - level: 40
+              name: developers
+          allowedtopush:
+            - level: 0
+              name: No one
+            - level: 40
+              name: Build Systems
+          branch: go1.17-boringcrypto
+          codeownerapproval: true
+    protectedtags: []
+    pushrules:
+        branchnameregex: ^(feature|topic)\/.+
+        commitcommittercheck: true
+        denydeletetag: true
+        filenameregex: (jar|exe)$
+        maxfilesize: 1
+        membercheck: true
+        preventsecrets: true
+        rejectunsignedcommits: false

--- a/assets/issues/issue-243/to.yml
+++ b/assets/issues/issue-243/to.yml
@@ -1,0 +1,112 @@
+project_id: 66800
+info:
+    members:
+        users:
+            - id: 13509
+              name: User3
+              maxrole: 30
+            - id: 552
+              name: User1
+              maxrole: 40
+            - id: 12141
+              name: User2
+              maxrole: 20
+        groups:
+            - id: 41866
+              name: approvers
+              maxrole: 30
+            - id: 41865
+              name: maintainers
+              maxrole: 40
+            - id: 3857
+              name: all
+              maxrole: 30
+            - id: 16951
+              name: developers
+              maxrole: 30
+general:
+    visibility:
+        public: false
+        visibility: internal
+        issuesaccesslevel: disabled
+        analyticsaccesslevel: enabled
+        securityandcomplianceaccesslevel: private
+        wikiaccesslevel: disabled
+        snippetsaccesslevel: disabled
+        mergerequestsaccesslevel: enabled
+        requestaccessenabled: false
+    mergerequests:
+        mergerequestsenabled: true
+        mergemethod: ff
+        mergepipelinesenabled: true
+        mergetrainsenabled: false
+        resolveoutdateddiffdiscussions: true
+        printingmergerequestlinkenabled: true
+        removesourcebranchaftermerge: true
+        squashoption: default_on
+        onlyallowmergeifpipelinesucceeds: true
+        allowmergeonskippedpipeline: false
+        onlyallowmergeifalldiscussionsareresolved: true
+        mergecommittemplate: ""
+        squashcommittemplate: ""
+    mergerequestapprovals:
+        mergerequestsauthorapproval: false
+        mergerequestsdisablecommittersapproval: false
+        disableoverridingapproverspermergerequest: true
+        requirepasswordtoapprove: false
+        resetapprovalsonpush: false
+        approvalrules:
+            - name: Git Approvers
+              users: []
+              groups:
+                - developers
+              targetbranch: []
+              required: 1
+repository:
+    defaultbranch:
+        defaultbranch: main
+        autoclosereferencedissues: true
+    pushrules:
+        membercheck: true
+        rejectunsignedcommits: false
+        denydeletetag: true
+        commitcommittercheck: true
+        preventsecrets: true
+        branchnameregex: ^(feature|topic)\/.+
+        filenameregex: (jar|exe)$
+        maxfilesize: 1
+    protectedbranches:
+        - branch: main
+          allowedtomerge:
+            - level: 40
+              name: developers
+          allowedtopush:
+            - level: 40
+              name: Build Systems
+            - level: 0
+              name: No one
+          allowedtoforcepush: false
+          codeownerapproval: true
+        - branch: go1.17-boringcrypto
+          allowedtomerge:
+            - level: 40
+              name: developers
+          allowedtopush:
+            - level: 40
+              name: Build Systems
+            - level: 0
+              name: No one
+          allowedtoforcepush: false
+          codeownerapproval: true
+    protectedtags: []
+cicd:
+    generalpipelines:
+        publicpipelines: false
+        autocancelredundantpipelines: enabled
+        gitstrategy: fetch
+        buildtimeout: 3600
+        buildcoverageregex: ""
+    runners: []
+    artifacts:
+        keepartifacts: true
+    variables: []

--- a/pkg/dyff/compare_test.go
+++ b/pkg/dyff/compare_test.go
@@ -1018,5 +1018,31 @@ b: bar
 				Expect(result.Diffs).To(HaveLen(0))
 			})
 		})
+
+		Context("input files containing complex objects with custom keys", func() {
+			It("cannot determine the keys through heuristics", func() {
+				from, to, err := ytbx.LoadFiles(assets("issues", "issue-243", "to.yml"), assets("issues", "issue-243", "from.yml"))
+				Expect(err).To(BeNil())
+				Expect(from).ToNot(BeNil())
+				Expect(to).ToNot(BeNil())
+
+				results, err := dyff.CompareInputFiles(from, to, dyff.IgnoreOrderChanges(true))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(results).ToNot(BeNil())
+				Expect(len(results.Diffs)).ToNot(Equal(0))
+			})
+
+			It("accurately reports no differences when keys are given", func() {
+				from, to, err := ytbx.LoadFiles(assets("issues", "issue-243", "to.yml"), assets("issues", "issue-243", "from.yml"))
+				Expect(err).To(BeNil())
+				Expect(from).ToNot(BeNil())
+				Expect(to).ToNot(BeNil())
+
+				results, err := dyff.CompareInputFiles(from, to, dyff.IgnoreOrderChanges(true), dyff.AdditionalIdentifiers("branch"))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(results).ToNot(BeNil())
+				Expect(len(results.Diffs)).To(Equal(0))
+			})
+		})
 	})
 })


### PR DESCRIPTION
To compare maps on complex YAMLs, the library requires that
items are compared by finding a key to match elements on.  There
is a heuristic list of identifying keys that works in most cases.

This change enables additional keys to be explicitly added for
YAMLs that follow a known schema.