### PR TITLE
Introduce `--additional-identifier` flag

### DIFF
--- a/internal/cmd/between.go
+++ b/internal/cmd/between.go
@@ -86,7 +86,9 @@ types are: YAML (http://yaml.org/) and JSON (http://json.org/).
 		report, err := dyff.CompareInputFiles(from, to,
 			dyff.IgnoreOrderChanges(reportOptions.ignoreOrderChanges),
 			dyff.KubernetesEntityDetection(reportOptions.kubernetesEntityDetection),
+			dyff.AdditionalIdentifiers(reportOptions.additionalIdentifiers...),
 		)
+
 		if err != nil {
 			return wrap.Errorf(err, "failed to compare input files")
 		}

--- a/internal/cmd/cmds_test.go
+++ b/internal/cmd/cmds_test.go
@@ -573,6 +573,12 @@ spec.replicas  (Deployment/default/test)
 
 `))
 		})
+
+		It("should accept additional identifier candidates for named-entry list processing", func() {
+			out, err := dyff("between", "--additional-identifier=branch", "--ignore-order-changes", "--omit-header", assets("issues", "issue-243", "from.yml"), assets("issues", "issue-243", "to.yml"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(BeEquivalentTo("\n"))
+		})
 	})
 
 	Context("last-applied command", func() {

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -47,6 +47,7 @@ type reportConfig struct {
 	exitWithCode              bool
 	omitHeader                bool
 	useGoPatchPaths           bool
+	additionalIdentifiers     []string
 	filters                   []string
 	excludes                  []string
 	filterRegexps             []string
@@ -62,6 +63,7 @@ var defaults = reportConfig{
 	exitWithCode:              false,
 	omitHeader:                false,
 	useGoPatchPaths:           false,
+	additionalIdentifiers:     nil,
 	filters:                   nil,
 	excludes:                  nil,
 	filterRegexps:             nil,
@@ -74,6 +76,7 @@ func applyReportOptionsFlags(cmd *cobra.Command) {
 	// Compare options
 	cmd.Flags().BoolVarP(&reportOptions.ignoreOrderChanges, "ignore-order-changes", "i", defaults.ignoreOrderChanges, "ignore order changes in lists")
 	cmd.Flags().BoolVarP(&reportOptions.kubernetesEntityDetection, "detect-kubernetes", "", defaults.kubernetesEntityDetection, "detect kubernetes entities")
+	cmd.Flags().StringArrayVar(&reportOptions.additionalIdentifiers, "additional-identifier", defaults.additionalIdentifiers, "use additional identifier candidates in named entry lists")
 	cmd.Flags().StringSliceVar(&reportOptions.filters, "filter", defaults.filters, "filter reports to a subset of differences based on supplied arguments")
 	cmd.Flags().StringSliceVar(&reportOptions.excludes, "exclude", defaults.excludes, "exclude reports from a set of differences based on supplied arguments")
 	cmd.Flags().StringSliceVar(&reportOptions.filterRegexps, "filter-regexp", defaults.filterRegexps, "filter reports to a subset of differences based on supplied regular expressions")

--- a/pkg/dyff/core.go
+++ b/pkg/dyff/core.go
@@ -792,7 +792,10 @@ func getEntryFromNamedList(sequenceNode *yamlv3.Node, identifier ListItemIdentif
 }
 
 func (compare *compare) listItemIdentifierCandidates() []ListItemIdentifierField {
+	// Set default candidates that are most widly used
 	var candidates = []ListItemIdentifierField{"name", "key", "id"}
+
+	// Add user supplied additional candidates (taking precedence over defaults)
 	candidates = append(compare.settings.AdditionalIdentifiers, candidates...)
 
 	// Add Kubernetes specific extra candidate


### PR DESCRIPTION
Add flag to `between` command to specified an additional custom
identifier for the named-entry list processing.
