### PR TITLE
Use `go get` for Ginkgo run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ clean:
 
 .PHONY: ginkgo
 ginkgo:
+	@go get github.com/onsi/ginkgo/v2/ginkgo/...
 	@go run github.com/onsi/ginkgo/v2/ginkgo \
 	  --coverprofile=unit.coverprofile \
 	  --randomize-all \


### PR DESCRIPTION
Use `go get` for Ginkgo run to avoid issues in CI.
```
go: downloading github.com/onsi/ginkgo/v2 v2.3.0
Error: ../../../go/pkg/mod/github.com/onsi/ginkgo/v2@v2.3.0/ginkgo/generators/bootstrap_command.go:9:2: missing go.sum entry for module providing package github.com/go-task/slim-sprig (imported by github.com/onsi/ginkgo/v2/ginkgo/generators); to add:
	go get github.com/onsi/ginkgo/v2/ginkgo/generators@v2.3.0
```