### PR TITLE
Tweak Ginkgo install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
 
     - name: Test
       run: |
-        go install github.com/onsi/ginkgo/v2/ginkgo
+        go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
         make test
 
     - name: Upload Code Coverage Profile


### PR DESCRIPTION
Add `-mod=mod` to hopefully get rid of `go.sum` issues.
