### PR TITLE
Enable Windows builds (again)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,7 @@ builds:
   - env:
     - CGO_ENABLED=0
     goos:
+    - windows
     - linux
     - darwin
     goarch:
@@ -14,11 +15,6 @@ builds:
     ldflags:
     - -s -w -extldflags "-static" -X github.com/homeport/dyff/internal/cmd.version={{.Version}}
     mod_timestamp: '{{ .CommitTimestamp }}'
-
-archives:
-- replacements:
-    darwin: darwin
-    linux: linux
 
 checksum:
   name_template: 'checksums.txt'

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ ginkgo run ./...
 Create binaries:
 
 ```bash
-goreleaser build --rm-dist --snapshot
+goreleaser build --clean --snapshot
 ```
 
 ## License


### PR DESCRIPTION
Add Windows to the list of build operating systems.

Replace `--rm-dist` with `--clean` since it is deprecated.

Remove replacements that are deprecated.
