### PR TITLE
Support apiVersion/kind in lists of kubernetes items

### DIFF
--- a/assets/kubernetes-lists/from.yml
+++ b/assets/kubernetes-lists/from.yml
@@ -10,7 +10,6 @@ items:
     name: foo-2
     namespace: foobar
 - apiVersion: v1
-  kind: Pod
   metadata:
     labels:
       foo: bAr

--- a/assets/kubernetes-lists/to.yml
+++ b/assets/kubernetes-lists/to.yml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: List
 items:
 - apiVersion: v1
-  kind: Pod
   metadata:
     labels:
       foo: bar

--- a/assets/matching-kubernetes-lists/input.yml
+++ b/assets/matching-kubernetes-lists/input.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: List
+metadata:
+  name: ingress-class
+items:
+  - apiVersion: v1
+    kind: kindv1
+    metadata:
+      name: item
+      labels:
+        id: 1
+  - apiVersion: v2
+    kind: kindv2
+    metadata:
+      name: item
+      labels:
+        id: 2

--- a/pkg/dyff/compare_test.go
+++ b/pkg/dyff/compare_test.go
@@ -818,6 +818,19 @@ b: bar
 			})
 		})
 
+		Context("given two identical kubernetes lists", func() {
+			It("should not report a difference", func() {
+				from, to := loadFiles(
+					assets("matching-kubernetes-lists", "input.yml"),
+					assets("matching-kubernetes-lists", "input.yml"),
+				)
+
+				results, err := dyff.CompareInputFiles(from, to, dyff.KubernetesEntityDetection(true))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(results.Diffs).To(BeNil())
+			})
+		})
+
 		Context("two YAML structures with Kubernetes lists", func() {
 			It("should identify individual list entries based on the nested name field in the respective entry metadata", func() {
 				from, to := loadFiles(
@@ -832,11 +845,11 @@ b: bar
 				Expect(results.Diffs[0]).To(BeSameDiffAs(singleDiff(
 					"#0/items",
 					dyff.ORDERCHANGE,
-					dyff.AsSequenceNode([]string{"foo-2", "foo-1"}),
-					dyff.AsSequenceNode([]string{"foo-1", "foo-2"}),
+					dyff.AsSequenceNode([]string{"v1:Pod:foo-2", "v1::foo-1"}),
+					dyff.AsSequenceNode([]string{"v1::foo-1", "v1:Pod:foo-2"}),
 				)))
 				Expect(results.Diffs[1]).To(BeSameDiffAs(singleDiff(
-					"/items/metadata.name=foo-1/metadata/labels/foo",
+					"/items/apiVersion:kind:metadata.name=v1::foo-1/metadata/labels/foo",
 					dyff.MODIFICATION,
 					"bAr",
 					"bar",


### PR DESCRIPTION
Previously list matching could produce incorrect results if a list had multiple items with the same metadata.name but different apiVersion/kind values. This happens for instance with some AWS charts (for instance [aws-load-balancer-controller](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/helm/aws-load-balancer-controller/templates/ingressclass.yaml)).

To address this, I added the concept of a composite identifier which identifies an item using multiple fields (in this case, `apiVersion`, `kind`, `metadata.name`). If all fields are empty, it's an error - otherwise we try a partial match.

This does lead to a slight change in the way things are named. To support multiple fields, the composite matches are separated by colons (`:`) - this only changes the behaviour for the Kubernetes entity path.

For the existing Kubernetes list test, this leads to the following diff:

Before:
```
  items
    ⇆ order changed
      - foo-2, foo-1
      + foo-1, foo-2

  items.v1:foo-1.metadata.labels.foo
    ± value change
      - bAr
      + bar
```

After:
```
  items
    ⇆ order changed
      - v1:Pod:foo-2, v1:foo-1
      + v1:foo-1, v1:Pod:foo-2

  items.v1:foo-1.metadata.labels.foo
    ± value change
      - bAr
      + bar
```
