### PR TITLE
Remove usage of deprecated `wrap.Error` function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gonvenience/neat v1.3.12
 	github.com/gonvenience/term v1.0.2
 	github.com/gonvenience/text v1.0.7
-	github.com/gonvenience/wrap v1.1.2
+	github.com/gonvenience/wrap v1.2.0
 	github.com/gonvenience/ytbx v1.4.4
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mitchellh/hashstructure v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/gonvenience/text v1.0.7 h1:YmIqmgTwxnACYCG59DykgMbomwteYyNhAmEUEJtPl1
 github.com/gonvenience/text v1.0.7/go.mod h1:OAjH+mohRszffLY6OjgQcUXiSkbrIavooFpfIt1ZwAs=
 github.com/gonvenience/wrap v1.1.2 h1:xPKxNwL1HCguwyM+HlP/1CIuc9LRd7k8RodLwe9YTZA=
 github.com/gonvenience/wrap v1.1.2/go.mod h1:GiryBSXoI3BAAhbWD1cZVj7RZmtiu0ERi/6R6eJfslI=
+github.com/gonvenience/wrap v1.2.0 h1:CwAoa60QIBVmQn/aUregAbk9FstEr17k9vCYpKF972c=
+github.com/gonvenience/wrap v1.2.0/go.mod h1:iNijaTmFD8+ORmNp9iS+dSBcCJrmIwwyoYLUngToGdk=
 github.com/gonvenience/ytbx v1.4.4 h1:jQopwyaLsVGuwdxSiN4WkXjsEaFNPJ3V4lUj7eyEpzo=
 github.com/gonvenience/ytbx v1.4.4/go.mod h1:w37+MKCPcCMY/jpPNmEklD4xKqrOAVBO6kIWW2+uI6M=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=

--- a/internal/cmd/between.go
+++ b/internal/cmd/between.go
@@ -21,7 +21,8 @@
 package cmd
 
 import (
-	"github.com/gonvenience/wrap"
+	"fmt"
+
 	"github.com/gonvenience/ytbx"
 	"github.com/spf13/cobra"
 
@@ -60,7 +61,7 @@ types are: YAML (http://yaml.org/) and JSON (http://json.org/).
 
 		from, to, err := ytbx.LoadFiles(fromLocation, toLocation)
 		if err != nil {
-			return wrap.Errorf(err, "failed to load input files")
+			return fmt.Errorf("failed to load input files: %w", err)
 		}
 
 		// If the main change root flag is set, this (re-)sets the individual change roots of the two input files
@@ -72,14 +73,14 @@ types are: YAML (http://yaml.org/) and JSON (http://json.org/).
 		// Change root of 'from' input file if change root flag for 'from' is set
 		if betweenCmdSettings.chrootFrom != "" {
 			if err = dyff.ChangeRoot(&from, betweenCmdSettings.chrootFrom, reportOptions.useGoPatchPaths, betweenCmdSettings.translateListToDocuments); err != nil {
-				return wrap.Errorf(err, "failed to change root of %s to path %s", from.Location, betweenCmdSettings.chrootFrom)
+				return fmt.Errorf("failed to change root of %s to path %s: %w", from.Location, betweenCmdSettings.chrootFrom, err)
 			}
 		}
 
 		// Change root of 'to' input file if change root flag for 'to' is set
 		if betweenCmdSettings.chrootTo != "" {
 			if err = dyff.ChangeRoot(&to, betweenCmdSettings.chrootTo, reportOptions.useGoPatchPaths, betweenCmdSettings.translateListToDocuments); err != nil {
-				return wrap.Errorf(err, "failed to change root of %s to path %s", to.Location, betweenCmdSettings.chrootTo)
+				return fmt.Errorf("failed to change root of %s to path %s: %w", to.Location, betweenCmdSettings.chrootTo, err)
 			}
 		}
 
@@ -90,7 +91,7 @@ types are: YAML (http://yaml.org/) and JSON (http://json.org/).
 		)
 
 		if err != nil {
-			return wrap.Errorf(err, "failed to compare input files")
+			return fmt.Errorf("failed to compare input files: %w", err)
 		}
 
 		if reportOptions.filters != nil {

--- a/internal/cmd/json.go
+++ b/internal/cmd/json.go
@@ -57,10 +57,7 @@ Converts input document into JSON format while preserving the order of all keys.
 		var errors []error
 		for _, filename := range args {
 			if ytbx.IsStdin(filename) && jsonCmdSettings.inplace {
-				return wrap.Error(
-					fmt.Errorf("cannot use in-place flag in combination with input from STDIN"),
-					"incompatible flags",
-				)
+				return fmt.Errorf("incompatible flags: %w", fmt.Errorf("cannot use in-place flag in combination with input from STDIN"))
 			}
 
 			if jsonCmdSettings.inplace {

--- a/internal/cmd/lastApplied.go
+++ b/internal/cmd/lastApplied.go
@@ -23,7 +23,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/gonvenience/wrap"
 	"github.com/gonvenience/ytbx"
 	"github.com/spf13/cobra"
 	yamlv3 "gopkg.in/yaml.v3"
@@ -61,7 +60,7 @@ to compare it against the current configuration.
 
 		report, err := dyff.CompareInputFiles(lastConfiguration, inputFile, dyff.IgnoreOrderChanges(reportOptions.ignoreOrderChanges))
 		if err != nil {
-			return wrap.Errorf(err, "failed to compare input files")
+			return fmt.Errorf("failed to compare input files: %w", err)
 		}
 
 		return writeReport(cmd, report)

--- a/internal/cmd/yaml.go
+++ b/internal/cmd/yaml.go
@@ -21,6 +21,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/gonvenience/bunt"
 	"github.com/gonvenience/wrap"
 	"github.com/gonvenience/ytbx"
@@ -57,10 +59,7 @@ Converts input document into YAML format while preserving the order of all keys.
 		var errors []error
 		for _, filename := range args {
 			if ytbx.IsStdin(filename) && yamlCmdSettings.inplace {
-				return wrap.Error(
-					bunt.Errorf("cannot use in-place flag in combination with input from _*stdin*_"),
-					"incompatible flags",
-				)
+				return fmt.Errorf("incompatible flags: %w", bunt.Errorf("cannot use in-place flag in combination with input from _*stdin*_"))
 			}
 
 			if yamlCmdSettings.inplace {

--- a/pkg/dyff/core.go
+++ b/pkg/dyff/core.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/gonvenience/bunt"
 	"github.com/gonvenience/text"
-	"github.com/gonvenience/wrap"
 	"github.com/gonvenience/ytbx"
 	"github.com/mitchellh/hashstructure"
 	yamlv3 "gopkg.in/yaml.v3"
@@ -961,7 +960,7 @@ func (compare *compare) calcNodeHash(node *yamlv3.Node) (hash uint64) {
 	}
 
 	if err != nil {
-		panic(wrap.Errorf(err, "failed to calculate hash of %#v", node.Value))
+		panic(fmt.Errorf("failed to calculate hash of %#v: %w", node.Value, err))
 	}
 
 	return hash


### PR DESCRIPTION
Use `fmt.Errorf` or `bunt.Errorf` instead.
