### PR TITLE
[TOOLS-1530] Add missing header line for document additions

### DIFF
--- a/pkg/dyff/output_human.go
+++ b/pkg/dyff/output_human.go
@@ -162,6 +162,11 @@ func (report *HumanReport) generateHumanDetailOutputAddition(detail Detail) (str
 	var output bytes.Buffer
 
 	switch detail.To.Kind {
+	case yamlv3.DocumentNode:
+		_, _ = fmt.Fprint(&output, yellow("%c %s added:\n",
+			ADDITION,
+			text.Plural(len(detail.To.Content), "document"),
+		))
 	case yamlv3.SequenceNode:
 		_, _ = output.WriteString(yellow("%c %s added:\n",
 			ADDITION,


### PR DESCRIPTION
There is a missing case in `switch` statement, for printing a header when a new document is added.


Before the change:
<img width="1005" alt="Screenshot 2024-01-15 at 20 40 49" src="https://github.com/homeport/dyff/assets/104995572/bd0d1148-eacc-4628-b396-4f4e70c71c47">


After the change:
<img width="892" alt="Screenshot 2024-01-15 at 20 40 18" src="https://github.com/homeport/dyff/assets/104995572/99cdbf7e-eafd-49a8-a643-6abca3086951">
