### PR TITLE
Package cleaning errors since golang 1.20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ all: clean test
 .PHONY: clean
 clean:
 	@rm -rf dist unit.coverprofile
-	@go clean -i -cache $(shell go list ./...)
+	@go clean -i -cache
 
 .PHONY: test
 test:


### PR DESCRIPTION
I guess adding packages to the `go clean` command always actually cleaned the whole cache, so adding this parameter was made into an error.

cref: https://github.com/golang/go/issues/53725