### PR TITLE
Ensure build without CVE-2024-24790

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ">= 1.22.4"
+          go-version: '>=1.22.4'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: ">= 1.22.4"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
Thanks for your efforts on dyff!

Currently our CVE-scanner complains about this:
https://www.cvedetails.com/cve/CVE-2024-24790/

A new release would be helpful