### PR TITLE
feat: Rename detection for Kubernetes resources

### DIFF
--- a/assets/kubernetes/multi-docs-file-level/expected-dyff.human
+++ b/assets/kubernetes/multi-docs-file-level/expected-dyff.human
@@ -1,0 +1,28 @@
+
+metadata  (v1/Service/foo)
+  + one map entry added:
+    annotations:
+      foo: bar
+
+(root level)  (v1/Service/foo-2)
+- one document removed:
+  ---
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: foo-2
+
+(root level)  (v1/Service/bar)
+  ---
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: bar
+
+(root level)  (v1/Service/baz)
+  ---
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: baz
+

--- a/assets/kubernetes/multi-docs-file-level/expected-dyff.human
+++ b/assets/kubernetes/multi-docs-file-level/expected-dyff.human
@@ -11,18 +11,29 @@ metadata  (v1/Service/foo)
   kind: Service
   metadata:
     name: foo-2
+  spec:
+    selector:
+      kubernetes.io/app: foo-2
 
 (root level)  (v1/Service/bar)
++ one document added:
   ---
   apiVersion: v1
   kind: Service
   metadata:
     name: bar
+  spec:
+    selector:
+      kubernetes.io/app: bar
 
 (root level)  (v1/Service/baz)
++ one document added:
   ---
   apiVersion: v1
   kind: Service
   metadata:
     name: baz
+  spec:
+    selector:
+      kubernetes.io/app: baz
 

--- a/assets/kubernetes/multi-docs-file-level/from.yaml
+++ b/assets/kubernetes/multi-docs-file-level/from.yaml
@@ -2,8 +2,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: foo
+spec:
+  selector:
+    kubernetes.io/app: foo
+
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: foo-2
+spec:
+  selector:
+    kubernetes.io/app: foo-2

--- a/assets/kubernetes/multi-docs-file-level/from.yaml
+++ b/assets/kubernetes/multi-docs-file-level/from.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: foo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: foo-2

--- a/assets/kubernetes/multi-docs-file-level/to.yaml
+++ b/assets/kubernetes/multi-docs-file-level/to.yaml
@@ -4,13 +4,24 @@ metadata:
   name: foo
   annotations:
     foo: bar
+spec:
+  selector:
+    kubernetes.io/app: foo
+
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: bar
+spec:
+  selector:
+    kubernetes.io/app: bar
+
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: baz
+spec:
+  selector:
+    kubernetes.io/app: baz

--- a/assets/kubernetes/multi-docs-file-level/to.yaml
+++ b/assets/kubernetes/multi-docs-file-level/to.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: foo
+  annotations:
+    foo: bar
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bar
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: baz

--- a/assets/kubernetes/rename/expected-dyff.human
+++ b/assets/kubernetes/rename/expected-dyff.human
@@ -1,0 +1,34 @@
+
+data.pinniped.yaml
+  ± value change in multiline text (one insert, no deletions)
+      discovery:
+        url: null
+      api:
+        servingCertificate:
+      
+      [two lines unchanged)]
+      
+      apiGroupSuffix: pinniped.dev
+      # aggregatedAPIServerPort may be set here, although other YAML references to the default port (10250) may also need to be updated
+      # impersonationProxyServerPort may be set here, although other YAML references to the default port (8444) may also need to be updated
+      names:
+    +   # Example comment
+        servingCertificateSecret: pinniped-concierge-api-tls-serving-certificate
+        credentialIssuer: pinniped-concierge-config
+        apiService: pinniped-concierge-api
+        impersonationLoadBalancerService: pinniped-concierge-impersonation-proxy-load-balancer
+      
+      [five lines unchanged)]
+      
+      labels: {"app": "pinniped-concierge"}
+      kubeCertAgent:
+        namePrefix: pinniped-concierge-kube-cert-agent-
+        image: projects.registry.vmware.com/pinniped/pinniped-server:latest
+  
+  
+
+metadata.name
+  ± value change
+    - pinniped-concierge-config-9bfbmfgt2f
+    + pinniped-concierge-config-296567ccmt
+

--- a/assets/kubernetes/rename/from.yaml
+++ b/assets/kubernetes/rename/from.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+data:
+  pinniped.yaml: |
+    discovery:
+      url: null
+    api:
+      servingCertificate:
+        durationSeconds: 2592000
+        renewBeforeSeconds: 2160000
+    apiGroupSuffix: pinniped.dev
+    # aggregatedAPIServerPort may be set here, although other YAML references to the default port (10250) may also need to be updated
+    # impersonationProxyServerPort may be set here, although other YAML references to the default port (8444) may also need to be updated
+    names:
+      servingCertificateSecret: pinniped-concierge-api-tls-serving-certificate
+      credentialIssuer: pinniped-concierge-config
+      apiService: pinniped-concierge-api
+      impersonationLoadBalancerService: pinniped-concierge-impersonation-proxy-load-balancer
+      impersonationClusterIPService: pinniped-concierge-impersonation-proxy-cluster-ip
+      impersonationTLSCertificateSecret: pinniped-concierge-impersonation-proxy-tls-serving-certificate
+      impersonationCACertificateSecret: pinniped-concierge-impersonation-proxy-ca-certificate
+      impersonationSignerSecret: pinniped-concierge-impersonation-proxy-signer-ca-certificate
+      agentServiceAccount: pinniped-concierge-kube-cert-agent
+    labels: {"app": "pinniped-concierge"}
+    kubeCertAgent:
+      namePrefix: pinniped-concierge-kube-cert-agent-
+      image: projects.registry.vmware.com/pinniped/pinniped-server:latest
+kind: ConfigMap
+metadata:
+  name: pinniped-concierge-config-9bfbmfgt2f

--- a/assets/kubernetes/rename/from/kustomization.yaml
+++ b/assets/kubernetes/rename/from/kustomization.yaml
@@ -1,0 +1,4 @@
+configMapGenerator:
+  - name: pinniped-concierge-config
+    files:
+      - pinniped.yaml

--- a/assets/kubernetes/rename/from/kustomization.yaml
+++ b/assets/kubernetes/rename/from/kustomization.yaml
@@ -1,3 +1,4 @@
+# Source: pinniped-concierge/templates/configmap-pinniped-concierge-config.yaml
 configMapGenerator:
   - name: pinniped-concierge-config
     files:

--- a/assets/kubernetes/rename/from/pinniped.yaml
+++ b/assets/kubernetes/rename/from/pinniped.yaml
@@ -1,0 +1,23 @@
+discovery:
+  url: null
+api:
+  servingCertificate:
+    durationSeconds: 2592000
+    renewBeforeSeconds: 2160000
+apiGroupSuffix: pinniped.dev
+# aggregatedAPIServerPort may be set here, although other YAML references to the default port (10250) may also need to be updated
+# impersonationProxyServerPort may be set here, although other YAML references to the default port (8444) may also need to be updated
+names:
+  servingCertificateSecret: pinniped-concierge-api-tls-serving-certificate
+  credentialIssuer: pinniped-concierge-config
+  apiService: pinniped-concierge-api
+  impersonationLoadBalancerService: pinniped-concierge-impersonation-proxy-load-balancer
+  impersonationClusterIPService: pinniped-concierge-impersonation-proxy-cluster-ip
+  impersonationTLSCertificateSecret: pinniped-concierge-impersonation-proxy-tls-serving-certificate
+  impersonationCACertificateSecret: pinniped-concierge-impersonation-proxy-ca-certificate
+  impersonationSignerSecret: pinniped-concierge-impersonation-proxy-signer-ca-certificate
+  agentServiceAccount: pinniped-concierge-kube-cert-agent
+labels: {"app": "pinniped-concierge"}
+kubeCertAgent:
+  namePrefix: pinniped-concierge-kube-cert-agent-
+  image: projects.registry.vmware.com/pinniped/pinniped-server:latest

--- a/assets/kubernetes/rename/to.yaml
+++ b/assets/kubernetes/rename/to.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+data:
+  pinniped.yaml: |
+    discovery:
+      url: null
+    api:
+      servingCertificate:
+        durationSeconds: 2592000
+        renewBeforeSeconds: 2160000
+    apiGroupSuffix: pinniped.dev
+    # aggregatedAPIServerPort may be set here, although other YAML references to the default port (10250) may also need to be updated
+    # impersonationProxyServerPort may be set here, although other YAML references to the default port (8444) may also need to be updated
+    names:
+      # Example comment
+      servingCertificateSecret: pinniped-concierge-api-tls-serving-certificate
+      credentialIssuer: pinniped-concierge-config
+      apiService: pinniped-concierge-api
+      impersonationLoadBalancerService: pinniped-concierge-impersonation-proxy-load-balancer
+      impersonationClusterIPService: pinniped-concierge-impersonation-proxy-cluster-ip
+      impersonationTLSCertificateSecret: pinniped-concierge-impersonation-proxy-tls-serving-certificate
+      impersonationCACertificateSecret: pinniped-concierge-impersonation-proxy-ca-certificate
+      impersonationSignerSecret: pinniped-concierge-impersonation-proxy-signer-ca-certificate
+      agentServiceAccount: pinniped-concierge-kube-cert-agent
+    labels: {"app": "pinniped-concierge"}
+    kubeCertAgent:
+      namePrefix: pinniped-concierge-kube-cert-agent-
+      image: projects.registry.vmware.com/pinniped/pinniped-server:latest
+kind: ConfigMap
+metadata:
+  name: pinniped-concierge-config-296567ccmt

--- a/assets/kubernetes/rename/to/kustomization.yaml
+++ b/assets/kubernetes/rename/to/kustomization.yaml
@@ -1,0 +1,4 @@
+configMapGenerator:
+  - name: pinniped-concierge-config
+    files:
+      - pinniped.yaml

--- a/assets/kubernetes/rename/to/kustomization.yaml
+++ b/assets/kubernetes/rename/to/kustomization.yaml
@@ -1,3 +1,4 @@
+# Source: pinniped-concierge/templates/configmap-pinniped-concierge-config.yaml
 configMapGenerator:
   - name: pinniped-concierge-config
     files:

--- a/assets/kubernetes/rename/to/pinniped.yaml
+++ b/assets/kubernetes/rename/to/pinniped.yaml
@@ -1,0 +1,24 @@
+discovery:
+  url: null
+api:
+  servingCertificate:
+    durationSeconds: 2592000
+    renewBeforeSeconds: 2160000
+apiGroupSuffix: pinniped.dev
+# aggregatedAPIServerPort may be set here, although other YAML references to the default port (10250) may also need to be updated
+# impersonationProxyServerPort may be set here, although other YAML references to the default port (8444) may also need to be updated
+names:
+  # Example comment
+  servingCertificateSecret: pinniped-concierge-api-tls-serving-certificate
+  credentialIssuer: pinniped-concierge-config
+  apiService: pinniped-concierge-api
+  impersonationLoadBalancerService: pinniped-concierge-impersonation-proxy-load-balancer
+  impersonationClusterIPService: pinniped-concierge-impersonation-proxy-cluster-ip
+  impersonationTLSCertificateSecret: pinniped-concierge-impersonation-proxy-tls-serving-certificate
+  impersonationCACertificateSecret: pinniped-concierge-impersonation-proxy-ca-certificate
+  impersonationSignerSecret: pinniped-concierge-impersonation-proxy-signer-ca-certificate
+  agentServiceAccount: pinniped-concierge-kube-cert-agent
+labels: {"app": "pinniped-concierge"}
+kubeCertAgent:
+  namePrefix: pinniped-concierge-kube-cert-agent-
+  image: projects.registry.vmware.com/pinniped/pinniped-server:latest

--- a/internal/cmd/cmds_test.go
+++ b/internal/cmd/cmds_test.go
@@ -594,13 +594,13 @@ spec.replicas  (apps/v1/Deployment/test)
 
 		It("should ignore the changes in values", func() {
 			expected := `
-(file level)
-  - one document removed:
-    ---
-    apiVersion: v1
-    kind: Namespace
-    metadata:
-      name: test
+(root level)  (v1/Namespace/test)
+- one document removed:
+  ---
+  apiVersion: v1
+  kind: Namespace
+  metadata:
+    name: test
 
 `
 			By("using the --ignore-value-changes", func() {
@@ -608,7 +608,6 @@ spec.replicas  (apps/v1/Deployment/test)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(out).To(BeEquivalentTo(expected))
 			})
-
 		})
 	})
 

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -98,6 +98,8 @@ func applyReportOptionsFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&reportOptions.noTableStyle, "no-table-style", "l", defaults.noTableStyle, "do not place blocks next to each other, always use one row per text block")
 	cmd.Flags().BoolVarP(&reportOptions.doNotInspectCerts, "no-cert-inspection", "x", defaults.doNotInspectCerts, "disable x509 certificate inspection, compare as raw text")
 	cmd.Flags().BoolVarP(&reportOptions.useGoPatchPaths, "use-go-patch-style", "g", defaults.useGoPatchPaths, "use Go-Patch style paths in outputs")
+	cmd.Flags().Float64VarP(&reportOptions.minorChangeThreshold, "minor-change-threshold", "", defaults.minorChangeThreshold, "minor change threshold")
+	cmd.Flags().IntVarP(&reportOptions.multilineContextLines, "multi-line-context-lines", "", defaults.multilineContextLines, "multi-line context lines")
 
 	// Deprecated
 	cmd.Flags().BoolVar(&reportOptions.exitWithCode, "set-exit-status", defaults.exitWithCode, "set program exit code, with 0 meaning no difference, 1 for differences detected, and 255 for program error")

--- a/pkg/dyff/output_human.go
+++ b/pkg/dyff/output_human.go
@@ -164,6 +164,12 @@ func (report *HumanReport) generateHumanDetailOutputAddition(detail Detail) (str
 	var output bytes.Buffer
 
 	switch detail.To.Kind {
+	case yamlv3.DocumentNode:
+		_, _ = fmt.Fprint(&output, yellow("%c %s added:\n",
+			ADDITION,
+			text.Plural(len(detail.To.Content), "document"),
+		))
+
 	case yamlv3.SequenceNode:
 		_, _ = output.WriteString(yellow("%c %s added:\n",
 			ADDITION,

--- a/pkg/dyff/output_human_test.go
+++ b/pkg/dyff/output_human_test.go
@@ -131,6 +131,15 @@ input: |+
 				true,
 			)
 		})
+
+		It("should report each file level change separately for better readability", func() {
+			compareAgainstExpectedHuman(
+				assets("kubernetes/multi-docs-file-level/from.yaml"),
+				assets("kubernetes/multi-docs-file-level/to.yaml"),
+				assets("kubernetes/multi-docs-file-level/expected-dyff.human"),
+				false,
+			)
+		})
 	})
 
 	Context("nicely colored human readable differences", func() {

--- a/pkg/dyff/output_human_test.go
+++ b/pkg/dyff/output_human_test.go
@@ -140,6 +140,15 @@ input: |+
 				false,
 			)
 		})
+
+		It("should detect renames for kubernetes documents", func() {
+			compareAgainstExpectedHuman(
+				assets("kubernetes/rename/from.yaml"),
+				assets("kubernetes/rename/to.yaml"),
+				assets("kubernetes/rename/expected-dyff.human"),
+				false,
+			)
+		})
 	})
 
 	Context("nicely colored human readable differences", func() {

--- a/pkg/dyff/rename/index.go
+++ b/pkg/dyff/rename/index.go
@@ -1,0 +1,290 @@
+package rename
+
+import (
+	"errors"
+	"io"
+	"sort"
+)
+
+const (
+	keyShift      = 32
+	maxCountValue = (1 << keyShift) - 1
+)
+
+var errIndexFull = errors.New("index is full")
+
+// similarityIndex is an index structure of lines/blocks in one file.
+// This structure can be used to compute an approximation of the similarity
+// between two files.
+// To save space in memory, this index uses a space efficient encoding which
+// will not exceed 1MiB per instance. The index starts out at a smaller size
+// (closer to 2KiB), but may grow as more distinct blocks within the scanned
+// file are discovered.
+// see: https://github.com/eclipse/jgit/blob/master/org.eclipse.jgit/src/org/eclipse/jgit/diff/SimilarityIndex.java
+type similarityIndex struct {
+	hashed uint64
+	// number of non-zero entries in hashes
+	numHashes int
+	growAt    int
+	hashes    []keyCountPair
+	hashBits  int
+}
+
+func fileSimilarityIndex(f File) (*similarityIndex, error) {
+	idx := newSimilarityIndex()
+	if err := idx.hash(f); err != nil {
+		return nil, err
+	}
+
+	sort.Stable(keyCountPairs(idx.hashes))
+
+	return idx, nil
+}
+
+func newSimilarityIndex() *similarityIndex {
+	return &similarityIndex{
+		hashBits: 8,
+		hashes:   make([]keyCountPair, 1<<8),
+		growAt:   shouldGrowAt(8),
+	}
+}
+
+func (i *similarityIndex) hash(f File) error {
+	r, err := f.Reader()
+	if err != nil {
+		return err
+	}
+
+	defer checkClose(r, &err)
+
+	size, err := f.Size()
+	if err != nil {
+		return err
+	}
+	return i.hashContent(r, size)
+}
+
+func (i *similarityIndex) hashContent(r io.Reader, size int64) error {
+	var buf = make([]byte, 4096)
+	var ptr, cnt int
+	remaining := size
+
+	for 0 < remaining {
+		hash := 5381
+		var blockHashedCnt uint64
+
+		// Hash one line or block, whatever happens first
+		n := int64(0)
+		for {
+			if ptr == cnt {
+				ptr = 0
+				var err error
+				cnt, err = io.ReadFull(r, buf)
+				if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
+					return err
+				}
+
+				if cnt == 0 {
+					return io.EOF
+				}
+			}
+			n++
+			c := buf[ptr] & 0xff
+			ptr++
+
+			// Ignore CR in CRLF sequence
+			if c == '\r' && ptr < cnt && buf[ptr] == '\n' {
+				continue
+			}
+			blockHashedCnt++
+
+			if c == '\n' {
+				break
+			}
+
+			hash = (hash << 5) + hash + int(c)
+
+			if n >= 64 || n >= remaining {
+				break
+			}
+		}
+		i.hashed += blockHashedCnt
+		if err := i.add(hash, blockHashedCnt); err != nil {
+			return err
+		}
+		remaining -= n
+	}
+
+	return nil
+}
+
+// score computes the similarity score between this index and another one.
+// A region of a file is defined as a line in a text file or a fixed-size
+// block in a binary file. To prepare an index, each region in the file is
+// hashed; the values and counts of hashes are retained in a sorted table.
+// Define the similarity fraction F as the count of matching regions between
+// the two files divided between the maximum count of regions in either file.
+// The similarity score is F multiplied by the maxScore constant, yielding a
+// range [0, maxScore]. It is defined as maxScore for the degenerate case of
+// two empty files.
+// The similarity score is symmetrical; i.e. a.score(b) == b.score(a).
+func (i *similarityIndex) score(other *similarityIndex, maxScore int) int {
+	var maxHashed = i.hashed
+	if maxHashed < other.hashed {
+		maxHashed = other.hashed
+	}
+	if maxHashed == 0 {
+		return maxScore
+	}
+
+	return int(i.common(other) * uint64(maxScore) / maxHashed)
+}
+
+func (i *similarityIndex) common(dst *similarityIndex) uint64 {
+	srcIdx, dstIdx := 0, 0
+	if i.numHashes == 0 || dst.numHashes == 0 {
+		return 0
+	}
+
+	var common uint64
+	srcKey, dstKey := i.hashes[srcIdx].key(), dst.hashes[dstIdx].key()
+
+	for {
+		if srcKey == dstKey {
+			srcCnt, dstCnt := i.hashes[srcIdx].count(), dst.hashes[dstIdx].count()
+			if srcCnt < dstCnt {
+				common += srcCnt
+			} else {
+				common += dstCnt
+			}
+
+			srcIdx++
+			if srcIdx == len(i.hashes) {
+				break
+			}
+			srcKey = i.hashes[srcIdx].key()
+
+			dstIdx++
+			if dstIdx == len(dst.hashes) {
+				break
+			}
+			dstKey = dst.hashes[dstIdx].key()
+		} else if srcKey < dstKey {
+			// Region of src that is not in dst
+			srcIdx++
+			if srcIdx == len(i.hashes) {
+				break
+			}
+			srcKey = i.hashes[srcIdx].key()
+		} else {
+			// Region of dst that is not in src
+			dstIdx++
+			if dstIdx == len(dst.hashes) {
+				break
+			}
+			dstKey = dst.hashes[dstIdx].key()
+		}
+	}
+
+	return common
+}
+
+func (i *similarityIndex) add(key int, cnt uint64) error {
+	key = int(uint32(key) * 0x9e370001 >> 1)
+
+	j := i.slot(key)
+	for {
+		v := i.hashes[j]
+		if v == 0 {
+			// It's an empty slot, so we can store it here.
+			if i.growAt <= i.numHashes {
+				if err := i.grow(); err != nil {
+					return err
+				}
+				j = i.slot(key)
+				continue
+			}
+
+			var err error
+			i.hashes[j], err = newKeyCountPair(key, cnt)
+			if err != nil {
+				return err
+			}
+			i.numHashes++
+			return nil
+		} else if v.key() == key {
+			// It's the same key, so increment the counter.
+			var err error
+			i.hashes[j], err = newKeyCountPair(key, v.count()+cnt)
+			return err
+		} else if j+1 >= len(i.hashes) {
+			j = 0
+		} else {
+			j++
+		}
+	}
+}
+
+type keyCountPair uint64
+
+func newKeyCountPair(key int, cnt uint64) (keyCountPair, error) {
+	if cnt > maxCountValue {
+		return 0, errIndexFull
+	}
+
+	return keyCountPair((uint64(key) << keyShift) | cnt), nil
+}
+
+func (p keyCountPair) key() int {
+	return int(p >> keyShift)
+}
+
+func (p keyCountPair) count() uint64 {
+	return uint64(p) & maxCountValue
+}
+
+func (i *similarityIndex) slot(key int) int {
+	// We use 31 - hashBits because the upper bit was already forced
+	// to be 0 and we want the remaining high bits to be used as the
+	// table slot.
+	return int(uint32(key) >> uint(31-i.hashBits))
+}
+
+func shouldGrowAt(hashBits int) int {
+	return (1 << uint(hashBits)) * (hashBits - 3) / hashBits
+}
+
+func (i *similarityIndex) grow() error {
+	if i.hashBits == 30 {
+		return errIndexFull
+	}
+
+	old := i.hashes
+
+	i.hashBits++
+	i.growAt = shouldGrowAt(i.hashBits)
+
+	// TODO: find a way to check if it will OOM and return errIndexFull instead.
+	i.hashes = make([]keyCountPair, 1<<uint(i.hashBits))
+
+	for _, v := range old {
+		if v != 0 {
+			j := i.slot(v.key())
+			for i.hashes[j] != 0 {
+				j++
+				if j >= len(i.hashes) {
+					j = 0
+				}
+			}
+			i.hashes[j] = v
+		}
+	}
+
+	return nil
+}
+
+type keyCountPairs []keyCountPair
+
+func (p keyCountPairs) Len() int           { return len(p) }
+func (p keyCountPairs) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p keyCountPairs) Less(i, j int) bool { return p[i] < p[j] }

--- a/pkg/dyff/rename/rename.go
+++ b/pkg/dyff/rename/rename.go
@@ -1,0 +1,294 @@
+// Package rename contains modified code from go-git's rename detection logic.
+//
+// go-git is licensed under Apache License 2.0, and you may obtain a copy of their original code and license from:
+// https://github.com/go-git/go-git
+package rename
+
+import (
+	"errors"
+	"io"
+	"sort"
+	"strings"
+)
+
+type DetectOptions struct {
+	// RenameScore is the threshold to of similarity between files to consider
+	// that a pair of delete and insert are a rename. The number must be
+	// exactly between 0 and 100.
+	RenameScore uint
+	// RenameLimit is the maximum amount of files that can be compared when
+	// detecting renames. The number of comparisons that have to be performed
+	// is equal to the number of deleted files * the number of added files.
+	// That means, that if 100 files were deleted and 50 files were added, 5000
+	// file comparisons may be needed. So, if the rename limit is 50, the number
+	// of both deleted and added needs to be equal or less than 50.
+	// A value of 0 means no limit.
+	RenameLimit uint
+}
+
+// DefaultDetectOptions are the default and recommended options.
+var DefaultDetectOptions = &DetectOptions{
+	RenameScore: 60,
+	RenameLimit: 50,
+}
+
+type Changes interface {
+	Deleted() []File
+	Added() []File
+
+	MarkAsRename(deleted, added File) error
+}
+
+type File interface {
+	Name() string
+	Reader() (io.ReadCloser, error)
+	Size() (int64, error)
+}
+
+// DetectRenames detects the renames in the given changes on two trees with
+// the given options. It will return the given changes grouping additions and
+// deletions into modifications when possible.
+// If options is nil, the default diff tree options will be used.
+func DetectRenames(
+	changes Changes,
+	opts *DetectOptions,
+) error {
+	if opts == nil {
+		opts = DefaultDetectOptions
+	}
+
+	detector := &renameDetector{
+		c:           changes,
+		deleted:     changes.Deleted(),
+		added:       changes.Added(),
+		renameScore: int(opts.RenameScore),
+		renameLimit: int(opts.RenameLimit),
+	}
+
+	return detector.detect()
+}
+
+// renameDetector will detect and resolve renames in a set of changes.
+// see: https://github.com/eclipse/jgit/blob/master/org.eclipse.jgit/src/org/eclipse/jgit/diff/RenameDetector.java
+type renameDetector struct {
+	c       Changes
+	deleted []File
+	added   []File
+
+	renameScore int
+	renameLimit int
+}
+
+func (d *renameDetector) detect() error {
+	if len(d.added) > 0 && len(d.deleted) > 0 {
+		return d.detectContentRenames()
+	}
+	return nil
+}
+
+// detectContentRenames detects renames based on the similarity of the content
+// in the files by building a matrix of pairs between sources and destinations
+// and matching by the highest score.
+// see: https://github.com/eclipse/jgit/blob/master/org.eclipse.jgit/src/org/eclipse/jgit/diff/SimilarityRenameDetector.java
+func (d *renameDetector) detectContentRenames() error {
+	cnt := max(len(d.added), len(d.deleted))
+	if d.renameLimit > 0 && cnt > d.renameLimit {
+		return nil
+	}
+
+	srcs, dsts := d.deleted, d.added
+	matrix, err := buildSimilarityMatrix(srcs, dsts, d.renameScore)
+	if err != nil {
+		return err
+	}
+
+	// Match rename pairs on a first-come-first-serve basis until
+	// we have looked at everything that is above the minimum score.
+	for i := len(matrix) - 1; i >= 0; i-- {
+		pair := matrix[i]
+		src := srcs[pair.deleted]
+		dst := dsts[pair.added]
+
+		if dst == nil || src == nil {
+			// It was already matched before
+			continue
+		}
+
+		if err = d.c.MarkAsRename(src, dst); err != nil {
+			return err
+		}
+
+		// Mark as matched
+		srcs[pair.deleted] = nil
+		dsts[pair.added] = nil
+	}
+	return nil
+}
+
+func nameSimilarityScore(a, b string) int {
+	aDirLen := strings.LastIndexByte(a, '/') + 1
+	bDirLen := strings.LastIndexByte(b, '/') + 1
+
+	dirMin := min(aDirLen, bDirLen)
+	dirMax := max(aDirLen, bDirLen)
+
+	var dirScoreLtr, dirScoreRtl int
+	if dirMax == 0 {
+		dirScoreLtr = 100
+		dirScoreRtl = 100
+	} else {
+		var dirSim int
+
+		for ; dirSim < dirMin; dirSim++ {
+			if a[dirSim] != b[dirSim] {
+				break
+			}
+		}
+
+		dirScoreLtr = dirSim * 100 / dirMax
+
+		if dirScoreLtr == 100 {
+			dirScoreRtl = 100
+		} else {
+			for dirSim = 0; dirSim < dirMin; dirSim++ {
+				if a[aDirLen-1-dirSim] != b[bDirLen-1-dirSim] {
+					break
+				}
+			}
+			dirScoreRtl = dirSim * 100 / dirMax
+		}
+	}
+
+	fileMin := min(len(a)-aDirLen, len(b)-bDirLen)
+	fileMax := max(len(a)-aDirLen, len(b)-bDirLen)
+
+	fileSim := 0
+	for ; fileSim < fileMin; fileSim++ {
+		if a[len(a)-1-fileSim] != b[len(b)-1-fileSim] {
+			break
+		}
+	}
+	fileScore := fileSim * 100 / fileMax
+
+	return (((dirScoreLtr + dirScoreRtl) * 25) + (fileScore * 50)) / 100
+}
+
+type similarityMatrix []similarityPair
+
+func (m similarityMatrix) Len() int      { return len(m) }
+func (m similarityMatrix) Swap(i, j int) { m[i], m[j] = m[j], m[i] }
+func (m similarityMatrix) Less(i, j int) bool {
+	if m[i].score == m[j].score {
+		if m[i].added == m[j].added {
+			return m[i].deleted < m[j].deleted
+		}
+		return m[i].added < m[j].added
+	}
+	return m[i].score < m[j].score
+}
+
+type similarityPair struct {
+	// index of the added file
+	added int
+	// index of the deleted file
+	deleted int
+	// similarity score
+	score int
+}
+
+const maxMatrixSize = 10000
+
+func buildSimilarityMatrix(srcs, dsts []File, renameScore int) (similarityMatrix, error) {
+	// Allocate for the worst-case scenario where every pair has a score
+	// that we need to consider. We might not need that many.
+	matrixSize := len(srcs) * len(dsts)
+	if matrixSize > maxMatrixSize {
+		matrixSize = maxMatrixSize
+	}
+	matrix := make(similarityMatrix, 0, matrixSize)
+	srcSizes := make([]int64, len(srcs))
+	dstSizes := make([]int64, len(dsts))
+	dstTooLarge := make(map[int]bool)
+
+	// Consider each pair of files, if the score is above the minimum
+	// threshold we need to record that scoring in the matrix so we can
+	// later find the best matches.
+outerLoop:
+	for srcIdx, src := range srcs {
+		// Declare the from file and the similarity index here to be able to
+		// reuse it inside the inner loop. The reason to not initialize them
+		// here is so we can skip the initialization in case they happen to
+		// not be needed later. They will be initialized inside the inner
+		// loop if and only if they're needed and reused in subsequent passes.
+		var s *similarityIndex
+		var err error
+		for dstIdx, dst := range dsts {
+			if dstTooLarge[dstIdx] {
+				continue
+			}
+
+			srcSize := srcSizes[srcIdx]
+			if srcSize == 0 {
+				srcSize, err = src.Size()
+				if err != nil {
+					return nil, err
+				}
+				srcSize += 1
+				srcSizes[srcIdx] = srcSize
+			}
+
+			dstSize := dstSizes[dstIdx]
+			if dstSize == 0 {
+				dstSize, err = dst.Size()
+				if err != nil {
+					return nil, err
+				}
+				dstSize += 1
+				dstSizes[dstIdx] = dstSize
+			}
+
+			minSize := min(srcSize, dstSize)
+			maxSize := max(srcSize, dstSize)
+
+			if int(minSize*100/maxSize) < renameScore {
+				// File sizes are too different to be a match
+				continue
+			}
+
+			if s == nil {
+				s, err = fileSimilarityIndex(src)
+				if err != nil {
+					if errors.Is(err, errIndexFull) {
+						continue outerLoop
+					}
+					return nil, err
+				}
+			}
+
+			di, err := fileSimilarityIndex(dst)
+			if err != nil {
+				if errors.Is(err, errIndexFull) {
+					dstTooLarge[dstIdx] = true
+				}
+
+				return nil, err
+			}
+
+			contentScore := s.score(di, 10000)
+			// The name score returns a value between 0 and 100, so we need to
+			// convert it to the same range as the content score.
+			nameScore := nameSimilarityScore(src.Name(), dst.Name()) * 100
+			score := (contentScore*99 + nameScore*1) / 10000
+
+			if score < renameScore {
+				continue
+			}
+
+			matrix = append(matrix, similarityPair{added: dstIdx, deleted: srcIdx, score: score})
+		}
+	}
+
+	sort.Stable(matrix)
+
+	return matrix, nil
+}

--- a/pkg/dyff/rename/util.go
+++ b/pkg/dyff/rename/util.go
@@ -1,0 +1,12 @@
+package rename
+
+import "io"
+
+// checkClose calls Close on the given io.Closer. If the given *error points to
+// nil, it will be assigned the error returned by Close. Otherwise, any error
+// returned by Close will be ignored. checkClose is usually called with defer.
+func checkClose(c io.Closer, err *error) {
+	if cerr := c.Close(); cerr != nil && *err == nil {
+		*err = cerr
+	}
+}

--- a/pkg/dyff/rename_detect.go
+++ b/pkg/dyff/rename_detect.go
@@ -1,0 +1,110 @@
+package dyff
+
+import (
+	"bytes"
+	"errors"
+	"github.com/gonvenience/ytbx"
+	"github.com/homeport/dyff/pkg/dyff/rename"
+	yamlv3 "gopkg.in/yaml.v3"
+	"io"
+)
+
+func mapSlice[E any, S ~[]E, T any](slice S, fn func(e E) T) []T {
+	ret := make([]T, len(slice))
+	for i, e := range slice {
+		ret[i] = fn(e)
+	}
+	return ret
+}
+
+func reject[E comparable, S ~[]E](slice S, elt E) (ret S, ok bool) {
+	ret = make(S, 0, len(slice))
+	for _, e := range slice {
+		if elt == e {
+			ok = true
+		} else {
+			ret = append(ret, e)
+		}
+	}
+	return
+}
+
+type modifiedPair struct {
+	from *renameCandidate
+	to   *renameCandidate
+}
+
+type documentChanges struct {
+	deleted []*renameCandidate
+	added   []*renameCandidate
+
+	modifiedPairs []modifiedPair
+}
+
+func newDocumentChanges(deleted []*renameCandidate, added []*renameCandidate) *documentChanges {
+	return &documentChanges{
+		deleted: deleted,
+		added:   added,
+	}
+}
+
+func (d *documentChanges) Deleted() []rename.File {
+	return mapSlice(d.deleted, func(r *renameCandidate) rename.File { return r })
+}
+
+func (d *documentChanges) Added() []rename.File {
+	return mapSlice(d.added, func(r *renameCandidate) rename.File { return r })
+}
+
+func (d *documentChanges) MarkAsRename(deleted, added rename.File) error {
+	var ok bool
+	d.deleted, ok = reject(d.deleted, deleted.(*renameCandidate))
+	if !ok {
+		return errors.New("deleted element not found")
+	}
+	d.added, ok = reject(d.added, added.(*renameCandidate))
+	if !ok {
+		return errors.New("added element not found")
+	}
+	d.modifiedPairs = append(d.modifiedPairs, modifiedPair{
+		from: deleted.(*renameCandidate),
+		to:   added.(*renameCandidate),
+	})
+	return nil
+}
+
+type renameCandidate struct {
+	path *ytbx.Path
+	doc  *yamlv3.Node
+
+	content []byte
+}
+
+func (r *renameCandidate) Name() string {
+	name, _ := k8sItem.Name(r.doc)
+	return name
+}
+
+func (r *renameCandidate) Reader() (io.ReadCloser, error) {
+	if r.content == nil {
+		if err := r.marshal(); err != nil {
+			return nil, err
+		}
+	}
+	return io.NopCloser(bytes.NewReader(r.content)), nil
+}
+
+func (r *renameCandidate) Size() (int64, error) {
+	if r.content == nil {
+		if err := r.marshal(); err != nil {
+			return 0, err
+		}
+	}
+	return int64(len(r.content)), nil
+}
+
+func (r *renameCandidate) marshal() error {
+	var err error
+	r.content, err = yamlv3.Marshal(r.doc)
+	return err
+}


### PR DESCRIPTION
Hello!

This pull request adds git-like rename detection logic for Kubernetes documents comparison.
For now, I have implemented this only for Kubernetes resources, whose name "keys" can be computed from `metadata.name` and other fields.
This is because additions and deletions can be computed only if these "keys" are present.

The heuristic rename detection logic was mostly taken from https://github.com/go-git/go-git.

I would love to use this feature in my use-case, that is, using configMapGenerator with kustomize.
Currently, changing file contents a little bit results in a huge diff, because the kustomize adds hash suffix to resource names.
This use-case is added as a test case under `./assets/kubernetes/rename` directory.
Example of real-life use-case: https://github.com/traPtitech/manifest/pull/600#issuecomment-2438868468

The implementation may still be rough-cut, so please feel free to correct or point out anything you don't like.

I've prepared a (pre-)release in my forked repository so you can install it and try it out with the following one-line script.
https://github.com/motoki317/dyff/releases
```bash
curl --silent --location https://git.io/JYfAY | ORG=motoki317 REPO=dyff bash
```

Thank you in advance!

resolves #359 