### PR TITLE
Add checked out ref for `actions/checkout@v4`

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,6 +23,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/misspell.yml
+++ b/.github/workflows/misspell.yml
@@ -23,6 +23,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Spellcheck
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,8 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Build
       run: go build ./...


### PR DESCRIPTION
When using third-party actions, it is recommended to, [pin actions to a full length commit SHA](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for security reasons.
The latest release of [actions/checkout@v4](https://github.com/actions/checkout/pull/1180) introduces the ability to add `ref: ${{ github.event.pull_request.head.sha }}`, allowing it to reference the most recent commit in a pull request.