### PR TITLE
feat(between): add ignore value changes flag

### DIFF
--- a/internal/cmd/between.go
+++ b/internal/cmd/between.go
@@ -111,6 +111,10 @@ types are: YAML (http://yaml.org/) and JSON (http://json.org/).
 			report = report.ExcludeRegexp(reportOptions.excludeRegexps...)
 		}
 
+		if reportOptions.ignoreValueChanges {
+			report = report.IgnoreValueChanges()
+		}
+
 		return writeReport(cmd, report)
 	},
 }

--- a/internal/cmd/cmds_test.go
+++ b/internal/cmd/cmds_test.go
@@ -591,6 +591,25 @@ spec.replicas  (apps/v1/Deployment/test)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(out).To(BeEquivalentTo("\n"))
 		})
+
+		It("should ignore the changes in values", func() {
+			expected := `
+(file level)
+  - one document removed:
+    ---
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: test
+
+`
+			By("using the --ignore-value-changes", func() {
+				out, err := dyff("between", "--omit-header", "--ignore-value-changes", assets("issues", "issue-232", "from.yml"), assets("issues", "issue-232", "to.yml"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).To(BeEquivalentTo(expected))
+			})
+
+		})
 	})
 
 	Context("last-applied command", func() {

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -47,6 +47,7 @@ type reportConfig struct {
 	exitWithCode              bool
 	omitHeader                bool
 	useGoPatchPaths           bool
+	ignoreValueChanges        bool
 	minorChangeThreshold      float64
 	multilineContextLines     int
 	additionalIdentifiers     []string
@@ -87,7 +88,7 @@ func applyReportOptionsFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&reportOptions.excludes, "exclude", defaults.excludes, "exclude reports from a set of differences based on supplied arguments")
 	cmd.Flags().StringSliceVar(&reportOptions.filterRegexps, "filter-regexp", defaults.filterRegexps, "filter reports to a subset of differences based on supplied regular expressions")
 	cmd.Flags().StringSliceVar(&reportOptions.excludeRegexps, "exclude-regexp", defaults.excludeRegexps, "exclude reports from a set of differences based on supplied regular expressions")
-
+	cmd.Flags().BoolVarP(&reportOptions.ignoreValueChanges, "ignore-value-changes", "v", false, "exclude changes in values")
 	// Main output preferences
 	cmd.Flags().StringVarP(&reportOptions.style, "output", "o", defaults.style, "specify the output style, supported styles: human, brief, github, gitlab, gitea")
 	cmd.Flags().BoolVarP(&reportOptions.omitHeader, "omit-header", "b", defaults.omitHeader, "omit the dyff summary header")

--- a/pkg/dyff/compare_test.go
+++ b/pkg/dyff/compare_test.go
@@ -831,6 +831,19 @@ listY: [ Yo, Yo, Yo ]
 
 				Expect(report.ExcludeRegexp("/does/not/exist")).To(BeEquivalentTo(report))
 			})
+
+			It("should ignore changes in values", func() {
+				report := dyff.Report{Diffs: []dyff.Diff{
+					singleDiff("/yaml/map/add", dyff.ADDITION, nil, "added"),
+					singleDiff("/yaml/map/removed", dyff.REMOVAL, nil, "removed"),
+					singleDiff("/yaml/map/changed", dyff.MODIFICATION, "foobar", "barfoo"),
+				}}
+
+				Expect(report.IgnoreValueChanges()).To(BeEquivalentTo(dyff.Report{Diffs: []dyff.Diff{
+					singleDiff("/yaml/map/add", dyff.ADDITION, nil, "added"),
+					singleDiff("/yaml/map/removed", dyff.REMOVAL, nil, "removed"),
+				}}))
+			})
 		})
 
 		Context("change root for comparison", func() {

--- a/pkg/dyff/reports.go
+++ b/pkg/dyff/reports.go
@@ -98,3 +98,26 @@ func (r Report) ExcludeRegexp(pattern ...string) (result Report) {
 		return true
 	})
 }
+
+func (r Report) IgnoreValueChanges() (result Report) {
+	result = Report{
+		From: r.From,
+		To:   r.To,
+	}
+
+	for _, diff := range r.Diffs {
+		var hasValChange = false
+		for _, detail := range diff.Details {
+			if detail.Kind == MODIFICATION {
+				hasValChange = true
+				break
+			}
+  		}
+
+		if !hasValChange {
+			result.Diffs = append(result.Diffs, diff)
+		}
+	}
+
+	return result	
+}


### PR DESCRIPTION
Sometimes it is useful to only include changes in structure and ignore the value changes. So I added a flag to drop such changes in the report.
--ignore-value-chnages