### PR TITLE
Tweak README file

### DIFF
--- a/.docs/commands/dyff.md
+++ b/.docs/commands/dyff.md
@@ -1,0 +1,30 @@
+## dyff
+
+dyff
+
+### Synopsis
+
+
+δyƒƒ /ˈdʏf/ - a diff tool for YAML files, and sometimes JSON. Also, It
+can transform YAML to JSON, and vice versa. The order of keys in hashes
+is preserved during the conversion.
+
+
+### Options
+
+```
+  -c, --color                        specify color usage: on, off, or auto (default auto)
+  -t, --truecolor                    specify true color usage: on, off, or auto (default auto)
+  -w, --fixed-width int              disable terminal width detection and use provided fixed value (default -1)
+  -k, --preserve-key-order-in-json   use ordered keys during JSON decoding (non standard behavior)
+  -h, --help                         help for dyff
+```
+
+### SEE ALSO
+
+* [dyff between](dyff_between.md)	 - Compare differences between input files from and to
+* [dyff json](dyff_json.md)	 - Converts input documents into JSON format
+* [dyff last-applied](dyff_last-applied.md)	 - Compare differences between the current state and the one stored in Kubernetes last-applied configuration
+* [dyff version](dyff_version.md)	 - Shows the version of this tool
+* [dyff yaml](dyff_yaml.md)	 - Converts input documents into YAML format
+

--- a/.docs/commands/dyff_between.md
+++ b/.docs/commands/dyff_between.md
@@ -1,0 +1,57 @@
+## dyff between
+
+Compare differences between input files from and to
+
+### Synopsis
+
+
+Compares differences between files and displays the delta. Supported input file
+types are: YAML (http://yaml.org/) and JSON (http://json.org/).
+
+
+```
+dyff between [flags] <from> <to>
+```
+
+### Options
+
+```
+  -i, --ignore-order-changes                ignore order changes in lists
+      --ignore-whitespace-changes           ignore leading or trailing whitespace changes
+      --detect-kubernetes                   detect kubernetes entities (default true)
+      --additional-identifier stringArray   use additional identifier candidates in named entry lists
+      --filter strings                      filter reports to a subset of differences based on supplied arguments
+      --exclude strings                     exclude reports from a set of differences based on supplied arguments
+      --filter-regexp strings               filter reports to a subset of differences based on supplied regular expressions
+      --exclude-regexp strings              exclude reports from a set of differences based on supplied regular expressions
+  -v, --ignore-value-changes                exclude changes in values
+      --detect-renames                      enable detection for renames (document level for Kubernetes resources) (default true)
+  -o, --output string                       specify the output style, supported styles: human, brief, github, gitlab, gitea (default "human")
+  -b, --omit-header                         omit the dyff summary header
+  -s, --set-exit-code                       set program exit code, with 0 meaning no difference, 1 for differences detected, and 255 for program error
+  -l, --no-table-style                      do not place blocks next to each other, always use one row per text block
+  -x, --no-cert-inspection                  disable x509 certificate inspection, compare as raw text
+  -g, --use-go-patch-style                  use Go-Patch style paths in outputs
+      --minor-change-threshold float        minor change threshold (default 0.1)
+      --multi-line-context-lines int        multi-line context lines (default 4)
+      --swap                                Swap 'from' and 'to' for comparison
+      --chroot string                       change the root level of the input file to another point in the document
+      --chroot-of-from string               only change the root level of the from input file
+      --chroot-of-to string                 only change the root level of the to input file
+      --chroot-list-to-documents            in case the change root points to a list, treat this list as a set of documents and not as the list itself
+  -h, --help                                help for between
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --color                        specify color usage: on, off, or auto (default auto)
+  -w, --fixed-width int              disable terminal width detection and use provided fixed value (default -1)
+  -k, --preserve-key-order-in-json   use ordered keys during JSON decoding (non standard behavior)
+  -t, --truecolor                    specify true color usage: on, off, or auto (default auto)
+```
+
+### SEE ALSO
+
+* [dyff](dyff.md)	 - dyff
+

--- a/.docs/commands/dyff_json.md
+++ b/.docs/commands/dyff_json.md
@@ -1,0 +1,37 @@
+## dyff json
+
+Converts input documents into JSON format
+
+### Synopsis
+
+
+Converts input document into JSON format while preserving the order of all keys.
+
+
+```
+dyff json [flags] <file-location> ...
+```
+
+### Options
+
+```
+  -p, --plain                output in plain style without any highlighting
+  -r, --restructure          restructure map keys in reasonable order
+  -O, --omit-indent-helper   omit indent helper lines in highlighted output
+  -i, --in-place             overwrite input file with output of this command
+  -h, --help                 help for json
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --color                        specify color usage: on, off, or auto (default auto)
+  -w, --fixed-width int              disable terminal width detection and use provided fixed value (default -1)
+  -k, --preserve-key-order-in-json   use ordered keys during JSON decoding (non standard behavior)
+  -t, --truecolor                    specify true color usage: on, off, or auto (default auto)
+```
+
+### SEE ALSO
+
+* [dyff](dyff.md)	 - dyff
+

--- a/.docs/commands/dyff_last-applied.md
+++ b/.docs/commands/dyff_last-applied.md
@@ -1,0 +1,53 @@
+## dyff last-applied
+
+Compare differences between the current state and the one stored in Kubernetes last-applied configuration
+
+### Synopsis
+
+
+Kubernetes resource YAML (or JSON) contain the previously used configuration of
+that resource in the metadata. For convenience, the respective metadata is used
+to compare it against the current configuration.
+
+
+```
+dyff last-applied [flags]
+```
+
+### Options
+
+```
+  -i, --ignore-order-changes                ignore order changes in lists
+      --ignore-whitespace-changes           ignore leading or trailing whitespace changes
+      --detect-kubernetes                   detect kubernetes entities (default true)
+      --additional-identifier stringArray   use additional identifier candidates in named entry lists
+      --filter strings                      filter reports to a subset of differences based on supplied arguments
+      --exclude strings                     exclude reports from a set of differences based on supplied arguments
+      --filter-regexp strings               filter reports to a subset of differences based on supplied regular expressions
+      --exclude-regexp strings              exclude reports from a set of differences based on supplied regular expressions
+  -v, --ignore-value-changes                exclude changes in values
+      --detect-renames                      enable detection for renames (document level for Kubernetes resources) (default true)
+  -o, --output string                       specify the output style, supported styles: human, brief, github, gitlab, gitea (default "human")
+  -b, --omit-header                         omit the dyff summary header
+  -s, --set-exit-code                       set program exit code, with 0 meaning no difference, 1 for differences detected, and 255 for program error
+  -l, --no-table-style                      do not place blocks next to each other, always use one row per text block
+  -x, --no-cert-inspection                  disable x509 certificate inspection, compare as raw text
+  -g, --use-go-patch-style                  use Go-Patch style paths in outputs
+      --minor-change-threshold float        minor change threshold (default 0.1)
+      --multi-line-context-lines int        multi-line context lines (default 4)
+  -h, --help                                help for last-applied
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --color                        specify color usage: on, off, or auto (default auto)
+  -w, --fixed-width int              disable terminal width detection and use provided fixed value (default -1)
+  -k, --preserve-key-order-in-json   use ordered keys during JSON decoding (non standard behavior)
+  -t, --truecolor                    specify true color usage: on, off, or auto (default auto)
+```
+
+### SEE ALSO
+
+* [dyff](dyff.md)	 - dyff
+

--- a/.docs/commands/dyff_version.md
+++ b/.docs/commands/dyff_version.md
@@ -1,0 +1,31 @@
+## dyff version
+
+Shows the version of this tool
+
+### Synopsis
+
+Shows the version of this tool
+
+```
+dyff version [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for version
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --color                        specify color usage: on, off, or auto (default auto)
+  -w, --fixed-width int              disable terminal width detection and use provided fixed value (default -1)
+  -k, --preserve-key-order-in-json   use ordered keys during JSON decoding (non standard behavior)
+  -t, --truecolor                    specify true color usage: on, off, or auto (default auto)
+```
+
+### SEE ALSO
+
+* [dyff](dyff.md)	 - dyff
+

--- a/.docs/commands/dyff_yaml.md
+++ b/.docs/commands/dyff_yaml.md
@@ -1,0 +1,37 @@
+## dyff yaml
+
+Converts input documents into YAML format
+
+### Synopsis
+
+
+Converts input document into YAML format while preserving the order of all keys.
+
+
+```
+dyff yaml [flags] <file-location> ...
+```
+
+### Options
+
+```
+  -p, --plain                output in plain style without any highlighting
+  -r, --restructure          restructure map keys in reasonable order
+  -O, --omit-indent-helper   omit indent helper lines in highlighted output
+  -i, --in-place             overwrite input file with output of this command
+  -h, --help                 help for yaml
+```
+
+### Options inherited from parent commands
+
+```
+  -c, --color                        specify color usage: on, off, or auto (default auto)
+  -w, --fixed-width int              disable terminal width detection and use provided fixed value (default -1)
+  -k, --preserve-key-order-in-json   use ordered keys during JSON decoding (non standard behavior)
+  -t, --truecolor                    specify true color usage: on, off, or auto (default auto)
+```
+
+### SEE ALSO
+
+* [dyff](dyff.md)	 - dyff
+

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Input files can be local files (filesystem path), remote files (URI), or the sta
 
 All orders of keys in hashes are preserved during processing and output to the terminal, most notably in the sub-commands to convert YAML to JSON and vice versa.
 
+## Command documentation
+
+See [command documentation](.docs/commands/dyff.md) for details about each command and its flags.
+
 ## Use cases and examples
 
 - Show differences between the live configuration of Kubernetes resources and what would be applied (`kubectl` version >= `v1.20.0`):
@@ -38,7 +42,7 @@ All orders of keys in hashes are preserved during processing and output to the t
   ![dyff between example with kubectl diff](.docs/dyff-between-kubectl-diff.png?raw=true "dyff in kubectl diff example")
 
   The `--set-exit-code` flag is required so that the `dyff` exit code matches `kubectl` expectations. An exit code `0` refers to no differences, `1` in case differences are detected. Other exit codes are treated as program issues.
-  
+
   _Note:_ Versions of `kubectl` older than `v1.20.0` did not split the environment variable into field, therefore you cannot use command arguments. In this case, you need to wrap the `dyff` command with its argument into a helper shell script and use this instead.
 
 - Show the differences between two versions of [`cf-deployment`](https://github.com/cloudfoundry/cf-deployment/) YAMLs:
@@ -118,16 +122,6 @@ On macOS, `dyff` is also [available via MacPorts](https://ports.macports.org/por
 ```bash
 sudo port install dyff
 ```
-
-### Snap
-
-It is [available in the `snapcraft` store](https://snapcraft.io/dyff) in the Productivity section.
-
-```bash
-snap install dyff
-```
-
-_Please note:_ Since `dyff` needs to use `strict` confinement due to otherwise manual clearance requirements, there are some limits to its usage. Most notably, users reported that in `strict` confinement reading files from the temporary directory does not work. This makes it impossible to use it in the `kubectl diff` use case. Consider using `brew`, or pre-built binaries instead.
 
 ### Pre-built binaries in GitHub
 

--- a/cmd/gendoc/main.go
+++ b/cmd/gendoc/main.go
@@ -1,0 +1,54 @@
+// Copyright © 2025 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/homeport/dyff/internal/cmd"
+	"github.com/spf13/cobra/doc"
+)
+
+const targetDir = ".docs/commands"
+
+func main() {
+	if err := mainE(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func mainE() error {
+	rcmd := cmd.NewRootCmd()
+	rcmd.Use = "dyff"
+	rcmd.Short = "dyff"
+	rcmd.DisableAutoGenTag = true
+
+	if err := os.RemoveAll(targetDir); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(targetDir, os.FileMode(0755)); err != nil {
+		return err
+	}
+
+	return doc.GenMarkdownTree(rcmd, targetDir)
+}

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3
 
 require (
 	github.com/BurntSushi/toml v1.4.0 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
@@ -37,6 +38,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/virtuald/go-ordered-json v0.0.0-20170621173500-b18e6e673d74 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -59,6 +60,7 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -83,6 +83,11 @@ is preserved during the conversion.
 `,
 }
 
+// NewRootCmd returns the root command (for generating documentation)
+func NewRootCmd() *cobra.Command {
+	return rootCmd
+}
+
 // ResetSettings resets command settings to default. This is only required by
 // the test suite to make sure that the flag parsing works correctly.
 func ResetSettings() {


### PR DESCRIPTION
Add section with command-line tool command documentation.

Add tool to generate command-line tool command documentation.

Remove the `snap` section, since this is no longer maintained.
