### PR TITLE
Fix panic when exit code does not have a cause

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -31,37 +31,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ExitCode is an error interface that has exit code (value) details
-type ExitCode interface {
-	Value() int
-	Cause() error
-	Error() string
-}
-
-// errorWithExitCode is just a way to transport the exit code to the main package
-type errorWithExitCode struct {
-	value int
-	cause error
-}
-
-var _ ExitCode = errorWithExitCode{}
-
-func (e errorWithExitCode) Value() int {
-	return e.value
-}
-
-func (e errorWithExitCode) Cause() error {
-	return e.cause
-}
-
-func (e errorWithExitCode) Error() string {
-	if e.cause != nil {
-		return e.cause.Error()
-	}
-
-	return ""
-}
-
 var name = func() string {
 	ep, err := os.Executable()
 	if err != nil {


### PR DESCRIPTION
Fixes: https://github.com/homeport/dyff/issues/448

Use `err.Error()` of `ExitCode` interface since this has a nil check.

Move `ExitCode` into its own source file.

Fix TYPO in comment about error.
