### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Starting with Go 1.17, you can install `dyff` from source using `go install`:
 go install github.com/homeport/dyff/cmd/dyff@latest
 ```
 
-_Please note:_ This will install `dyff` based on the latest available code base. Even though the goal is that the latest commit on the `main` branch should always be a stable and usable version, this is not the recommended way to install and use `dyff`. If you find an issue with this version, please make sure to note the commit SHA or date in the GitHub issue to indcate that it is not based on a released version. The version output will show `dyff version (development)` for `go install` based builds.
+_Please note:_ This will install `dyff` based on the latest available code base. Even though the goal is that the latest commit on the `main` branch should always be a stable and usable version, this is not the recommended way to install and use `dyff`. If you find an issue with this version, please make sure to note the commit SHA or date in the GitHub issue to indicate that it is not based on a released version. The version output will show `dyff version (development)` for `go install` based builds.
 
 ## Contributing
 

--- a/assets/bosh-yaml/manifest.yml
+++ b/assets/bosh-yaml/manifest.yml
@@ -15,7 +15,7 @@ instance_groups:
     resource_pool: concourse_resource_pool
     networks:
       - name: concourse
-        static_ips: [XX.XX.XX.XX]  # ADD THE STATIC IP ADDRESSES FOR YOUR web INSTACES HERE IF APPLICABLE, OTHERWISE DELETE THIS SECTION
+        static_ips: [XX.XX.XX.XX]  # ADD THE STATIC IP ADDRESSES FOR YOUR web INSTANCES HERE IF APPLICABLE, OTHERWISE DELETE THIS SECTION
     jobs:
       - release: concourse
         name: atc
@@ -80,9 +80,9 @@ resource_pools:
 - name: concourse_resource_pool
   stemcell:
     name: bosh-vsphere-esxi-ubuntu-trusty-go_agent  # UPDATE ACCORDINGLY WITH THE STEMCELL ID FOR THE TARGETED IaaS
-    version: '3232.2'   # UDPATE ACCORDINGLY WITH THE UPLOADED STEMCELL VERSION
+    version: '3232.2'   # UPDATE ACCORDINGLY WITH THE UPLOADED STEMCELL VERSION
   network: concourse
-  cloud_properties:    # UDPATE THIS SECTION ACCORDINGLY BASED ON YOUR VM DEFINITIONS AND CLUSTER INFO
+  cloud_properties:    # UPDATE THIS SECTION ACCORDINGLY BASED ON YOUR VM DEFINITIONS AND CLUSTER INFO
     ram: 4096
     disk: 32768
     cpu: 2
@@ -94,7 +94,7 @@ compilation:
   reuse_compilation_vms: true
   workers: 3
   network: concourse
-  cloud_properties:   # UDPATE THIS SECTION ACCORDINGLY BASED ON YOUR VM DEFINITIONS AND CLUSTER INFO
+  cloud_properties:   # UPDATE THIS SECTION ACCORDINGLY BASED ON YOUR VM DEFINITIONS AND CLUSTER INFO
     ram: 4096
     disk: 32768
     cpu: 2

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -99,7 +99,7 @@ func Execute() error {
 		// Add implicit exclude for metadata.managedFields as this cannot
 		// be configured via a command-line flag using KUBECTL_EXTERNAL_DIFF
 		// due to an bug/feature in kubectl that ignore command-line flags
-		// in the diff environment variable with non alpha-numeric characters
+		// in the diff environment variable with non alphanumeric characters
 		reportOptions.excludeRegexps = append(reportOptions.excludeRegexps, "^/metadata/managedFields")
 	}
 

--- a/pkg/dyff/core_suite_test.go
+++ b/pkg/dyff/core_suite_test.go
@@ -194,7 +194,7 @@ func compareAgainstExpectedDiffSyntax(fromPath string, toPath string, expectedPa
 }
 
 func yml(input string) *yamlv3.Node {
-	// If input is a file loacation, load this as YAML
+	// If input is a file location, load this as YAML
 	if _, err := os.Open(input); err == nil {
 		var content ytbx.InputFile
 		var err error

--- a/pkg/dyff/output_human.go
+++ b/pkg/dyff/output_human.go
@@ -382,7 +382,7 @@ func (report *HumanReport) writeStringDiff(output stringWriter, from string, to 
 				del++
 
 			case diffmatchpatch.DiffEqual:
-				// skip eqaul output if requested context is 0 or the equal text is empty
+				// skip equal output if requested context is 0 or the equal text is empty
 				if multilineContextLines <= 0 || len(d.Text) == 0 {
 					continue
 				}


### PR DESCRIPTION
Found via `codespell -L te`