### PR TITLE
feat: allow kubernetes generateName

### DIFF
--- a/assets/issues/issue-491/from.yml
+++ b/assets/issues/issue-491/from.yml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: a-service-account

--- a/assets/issues/issue-491/to.yml
+++ b/assets/issues/issue-491/to.yml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: a-service-account
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: a-generated-name-
+spec:
+  template:
+    spec:
+      serviceAccountName: a-service-account
+      containers:
+        - name: job
+          image: nginx:latest
+      restartPolicy: Never
+  backoffLimit: 2

--- a/internal/cmd/between.go
+++ b/internal/cmd/between.go
@@ -88,6 +88,7 @@ types are: YAML (http://yaml.org/) and JSON (http://json.org/).
 			dyff.IgnoreOrderChanges(reportOptions.ignoreOrderChanges),
 			dyff.IgnoreWhitespaceChanges(reportOptions.ignoreWhitespaceChanges),
 			dyff.KubernetesEntityDetection(reportOptions.kubernetesEntityDetection),
+			dyff.KubernetesEntityDetectionMatchGenerateName(reportOptions.kubernetesEntityDetectionMatchGenerateName),
 			dyff.AdditionalIdentifiers(reportOptions.additionalIdentifiers...),
 			dyff.DetectRenames(reportOptions.detectRenames),
 		)

--- a/internal/cmd/cmds_test.go
+++ b/internal/cmd/cmds_test.go
@@ -609,6 +609,34 @@ spec.replicas  (apps/v1/Deployment/test)
 				Expect(out).To(BeEquivalentTo(expected))
 			})
 		})
+
+		It("should use match on generateName if enabled", func() {
+			expected := `
+(root level)
++ one document added:
+  ---
+  apiVersion: batch/v1
+  kind: Job
+  metadata:
+    generateName: a-generated-name-
+  spec:
+    template:
+      spec:
+        serviceAccountName: a-service-account
+        containers:
+        - name: job
+          image: "nginx:latest"
+        restartPolicy: Never
+    backoffLimit: 2
+
+`
+
+			By("using the --detect-kubernetes-generated-name flag", func() {
+				out, err := dyff("between", "--omit-header", "--detect-kubernetes-generate-name", assets("issues", "issue-491", "from.yml"), assets("issues", "issue-491", "to.yml"))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(out).To(BeEquivalentTo(expected))
+			})
+		})
 	})
 
 	Context("last-applied command", func() {

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -38,24 +38,25 @@ import (
 )
 
 type reportConfig struct {
-	style                     string
-	ignoreOrderChanges        bool
-	ignoreWhitespaceChanges   bool
-	kubernetesEntityDetection bool
-	noTableStyle              bool
-	doNotInspectCerts         bool
-	exitWithCode              bool
-	omitHeader                bool
-	useGoPatchPaths           bool
-	ignoreValueChanges        bool
-	detectRenames             bool
-	minorChangeThreshold      float64
-	multilineContextLines     int
-	additionalIdentifiers     []string
-	filters                   []string
-	excludes                  []string
-	filterRegexps             []string
-	excludeRegexps            []string
+	style                                      string
+	ignoreOrderChanges                         bool
+	ignoreWhitespaceChanges                    bool
+	kubernetesEntityDetection                  bool
+	kubernetesEntityDetectionMatchGenerateName bool
+	noTableStyle                               bool
+	doNotInspectCerts                          bool
+	exitWithCode                               bool
+	omitHeader                                 bool
+	useGoPatchPaths                            bool
+	ignoreValueChanges                         bool
+	detectRenames                              bool
+	minorChangeThreshold                       float64
+	multilineContextLines                      int
+	additionalIdentifiers                      []string
+	filters                                    []string
+	excludes                                   []string
+	filterRegexps                              []string
+	excludeRegexps                             []string
 }
 
 var defaults = reportConfig{
@@ -63,20 +64,21 @@ var defaults = reportConfig{
 	ignoreOrderChanges:        false,
 	ignoreWhitespaceChanges:   false,
 	kubernetesEntityDetection: true,
-	noTableStyle:              false,
-	doNotInspectCerts:         false,
-	exitWithCode:              false,
-	omitHeader:                false,
-	useGoPatchPaths:           false,
-	ignoreValueChanges:        false,
-	detectRenames:             true,
-	minorChangeThreshold:      0.1,
-	multilineContextLines:     4,
-	additionalIdentifiers:     nil,
-	filters:                   nil,
-	excludes:                  nil,
-	filterRegexps:             nil,
-	excludeRegexps:            nil,
+	kubernetesEntityDetectionMatchGenerateName: false,
+	noTableStyle:          false,
+	doNotInspectCerts:     false,
+	exitWithCode:          false,
+	omitHeader:            false,
+	useGoPatchPaths:       false,
+	ignoreValueChanges:    false,
+	detectRenames:         true,
+	minorChangeThreshold:  0.1,
+	multilineContextLines: 4,
+	additionalIdentifiers: nil,
+	filters:               nil,
+	excludes:              nil,
+	filterRegexps:         nil,
+	excludeRegexps:        nil,
 }
 
 var reportOptions reportConfig
@@ -86,6 +88,7 @@ func applyReportOptionsFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&reportOptions.ignoreOrderChanges, "ignore-order-changes", "i", defaults.ignoreOrderChanges, "ignore order changes in lists")
 	cmd.Flags().BoolVar(&reportOptions.ignoreWhitespaceChanges, "ignore-whitespace-changes", defaults.ignoreWhitespaceChanges, "ignore leading or trailing whitespace changes")
 	cmd.Flags().BoolVarP(&reportOptions.kubernetesEntityDetection, "detect-kubernetes", "", defaults.kubernetesEntityDetection, "detect kubernetes entities")
+	cmd.Flags().BoolVarP(&reportOptions.kubernetesEntityDetectionMatchGenerateName, "detect-kubernetes-generate-name", "", defaults.kubernetesEntityDetectionMatchGenerateName, "also match generated names for kubernetes entities (e.g. 'batch/v1/Job/metadata.generateName=foo')")
 	cmd.Flags().StringArrayVar(&reportOptions.additionalIdentifiers, "additional-identifier", defaults.additionalIdentifiers, "use additional identifier candidates in named entry lists")
 	cmd.Flags().StringSliceVar(&reportOptions.filters, "filter", defaults.filters, "filter reports to a subset of differences based on supplied arguments")
 	cmd.Flags().StringSliceVar(&reportOptions.excludes, "exclude", defaults.excludes, "exclude reports from a set of differences based on supplied arguments")

--- a/pkg/dyff/compare_test.go
+++ b/pkg/dyff/compare_test.go
@@ -1098,6 +1098,30 @@ b: bar
 				Expect(err).NotTo(HaveOccurred())
 				Expect(result.Diffs).To(HaveLen(0))
 			})
+
+			It("should match on generateName if enabled", func() {
+				from := ytbx.InputFile{
+					Location: "/ginkgo/compare/test/from",
+					Documents: multiDoc(
+						`{"apiVersion": "batch/v1", "kind": "Job", "metadata": {"generateName": "x"}}`,
+						`{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "y"}}`,
+					),
+				}
+
+				to := ytbx.InputFile{
+					Location: "/ginkgo/compare/test/to",
+					Documents: multiDoc(
+						`{"apiVersion": "batch/v1", "kind": "Job", "metadata": {"generateName": "x"}}`,
+						``,
+						`{"apiVersion": "v1", "kind": "Service", "metadata": {"name": "y"}}`,
+						``,
+					),
+				}
+
+				result, err := dyff.CompareInputFiles(from, to, dyff.KubernetesEntityDetectionMatchGenerateName(true))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Diffs).To(HaveLen(0))
+			})
 		})
 
 		Context("input files containing complex objects with custom keys", func() {


### PR DESCRIPTION
Kubernetes provides the ability to create objects with generateName, which acts as a prefix and the suffix is added by the api-server and returned to the client.  I discovered while attempting to diff my manifest using dyff that this seems unsupported at the moment.

I'm proposing adding a new flag here to maintain backwards compatibility that will enable matching on generateName.

Closes #491 