### PR TITLE
feat: add flags to filter entire documents from report

### DIFF
--- a/internal/cmd/between.go
+++ b/internal/cmd/between.go
@@ -112,6 +112,22 @@ types are: YAML (http://yaml.org/) and JSON (http://json.org/).
 			report = report.ExcludeRegexp(reportOptions.excludeRegexps...)
 		}
 
+		if reportOptions.filterDocuments != nil {
+			report = report.FilterDocument(reportOptions.filterDocuments...)
+		}
+
+		if reportOptions.filterDocumentRegexps != nil {
+			report = report.FilterDocumentRegexp(reportOptions.filterDocumentRegexps...)
+		}
+
+		if reportOptions.excludeDocuments != nil {
+			report = report.ExcludeDocument(reportOptions.excludeDocuments...)
+		}
+
+		if reportOptions.excludeDocumentRegexps != nil {
+			report = report.ExcludeDocumentRegexp(reportOptions.excludeDocumentRegexps...)
+		}
+
 		if reportOptions.ignoreValueChanges {
 			report = report.IgnoreValueChanges()
 		}

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -56,6 +56,10 @@ type reportConfig struct {
 	excludes                  []string
 	filterRegexps             []string
 	excludeRegexps            []string
+	filterDocuments           []string
+	excludeDocuments          []string
+	filterDocumentRegexps     []string
+	excludeDocumentRegexps    []string
 }
 
 var defaults = reportConfig{
@@ -77,6 +81,10 @@ var defaults = reportConfig{
 	excludes:                  nil,
 	filterRegexps:             nil,
 	excludeRegexps:            nil,
+	filterDocuments:           nil,
+	excludeDocuments:          nil,
+	filterDocumentRegexps:     nil,
+	excludeDocumentRegexps:    nil,
 }
 
 var reportOptions reportConfig
@@ -91,6 +99,10 @@ func applyReportOptionsFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&reportOptions.excludes, "exclude", defaults.excludes, "exclude reports from a set of differences based on supplied arguments")
 	cmd.Flags().StringSliceVar(&reportOptions.filterRegexps, "filter-regexp", defaults.filterRegexps, "filter reports to a subset of differences based on supplied regular expressions")
 	cmd.Flags().StringSliceVar(&reportOptions.excludeRegexps, "exclude-regexp", defaults.excludeRegexps, "exclude reports from a set of differences based on supplied regular expressions")
+	cmd.Flags().StringSliceVar(&reportOptions.filterDocuments, "filter-document", defaults.filterDocuments, "filter report to a subset of documents")
+	cmd.Flags().StringSliceVar(&reportOptions.excludeDocuments, "exclude-document", defaults.excludeDocuments, "exclude documents from report")
+	cmd.Flags().StringSliceVar(&reportOptions.filterDocumentRegexps, "filter-document-regexp", defaults.filterDocumentRegexps, "filter report to a subset of documents based on supplied regular expressions")
+	cmd.Flags().StringSliceVar(&reportOptions.excludeDocumentRegexps, "exclude-document-regexp", defaults.excludeDocumentRegexps, "exclude documents from report based on supplied regular expressions")
 	cmd.Flags().BoolVarP(&reportOptions.ignoreValueChanges, "ignore-value-changes", "v", defaults.ignoreValueChanges, "exclude changes in values")
 	cmd.Flags().BoolVar(&reportOptions.detectRenames, "detect-renames", defaults.detectRenames, "enable detection for renames (document level for Kubernetes resources)")
 

--- a/pkg/dyff/reports.go
+++ b/pkg/dyff/reports.go
@@ -57,6 +57,38 @@ func (r Report) Exclude(paths ...string) (result Report) {
 	})
 }
 
+func (r Report) FilterDocument(paths ...string) (result Report) {
+	if len(paths) == 0 {
+		return r
+	}
+
+	return r.filter(func(filterPath *ytbx.Path) bool {
+		for _, pathString := range paths {
+			if filterPath != nil && pathString == filterPath.RootDescription() {
+				return true
+			}
+		}
+
+		return false
+	})
+}
+
+func (r Report) ExcludeDocument(paths ...string) (result Report) {
+	if len(paths) == 0 {
+		return r
+	}
+
+	return r.filter(func(filterPath *ytbx.Path) bool {
+		for _, pathString := range paths {
+			if filterPath != nil && pathString == filterPath.RootDescription() {
+				return false
+			}
+		}
+
+		return true
+	})
+}
+
 // FilterRegexp accepts regular expressions as input and returns a new report with differences for matching those patterns
 func (r Report) FilterRegexp(pattern ...string) (result Report) {
 	if len(pattern) == 0 {
@@ -99,6 +131,46 @@ func (r Report) ExcludeRegexp(pattern ...string) (result Report) {
 	})
 }
 
+func (r Report) FilterDocumentRegexp(pattern ...string) (result Report) {
+	if len(pattern) == 0 {
+		return r
+	}
+
+	regexps := make([]*regexp.Regexp, len(pattern))
+	for i := range pattern {
+		regexps[i] = regexp.MustCompile(pattern[i])
+	}
+
+	return r.filter(func(filterPath *ytbx.Path) bool {
+		for _, r := range regexps {
+			if filterPath != nil && r.MatchString(filterPath.RootDescription()) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func (r Report) ExcludeDocumentRegexp(pattern ...string) (result Report) {
+	if len(pattern) == 0 {
+		return r
+	}
+
+	regexps := make([]*regexp.Regexp, len(pattern))
+	for i := range pattern {
+		regexps[i] = regexp.MustCompile(pattern[i])
+	}
+
+	return r.filter(func(filterPath *ytbx.Path) bool {
+		for _, r := range regexps {
+			if filterPath != nil && r.MatchString(filterPath.RootDescription()) {
+				return false
+			}
+		}
+		return true
+	})
+}
+
 func (r Report) IgnoreValueChanges() (result Report) {
 	result = Report{
 		From: r.From,
@@ -112,12 +184,12 @@ func (r Report) IgnoreValueChanges() (result Report) {
 				hasValChange = true
 				break
 			}
-  		}
+		}
 
 		if !hasValChange {
 			result.Diffs = append(result.Diffs, diff)
 		}
 	}
 
-	return result	
+	return result
 }


### PR DESCRIPTION
There is currently functionality to filter/ignore fields from a `dyff` using yaml or go paths. This is very handy for cleaning up the report when you expect there to be certain changes. Unfortunately, a document removal or addition is impossible to filter/ignore this way since the path to the field being changed is `.`

This PR addresses that issue and allows you to ignore entire documents so you can filter out documents that you expect to be removed, added, or don't care about any changes in them.