### PR TITLE
feat: marshal strings to json before comparison

### DIFF
--- a/internal/cmd/between.go
+++ b/internal/cmd/between.go
@@ -90,6 +90,7 @@ types are: YAML (http://yaml.org/) and JSON (http://json.org/).
 			dyff.KubernetesEntityDetection(reportOptions.kubernetesEntityDetection),
 			dyff.AdditionalIdentifiers(reportOptions.additionalIdentifiers...),
 			dyff.DetectRenames(reportOptions.detectRenames),
+			dyff.MarshalJsonStrings(reportOptions.marshalJsonStrings),
 		)
 
 		if err != nil {

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -49,6 +49,7 @@ type reportConfig struct {
 	useGoPatchPaths           bool
 	ignoreValueChanges        bool
 	detectRenames             bool
+	marshalJsonStrings        bool
 	minorChangeThreshold      float64
 	multilineContextLines     int
 	additionalIdentifiers     []string
@@ -70,6 +71,7 @@ var defaults = reportConfig{
 	useGoPatchPaths:           false,
 	ignoreValueChanges:        false,
 	detectRenames:             true,
+	marshalJsonStrings:        false,
 	minorChangeThreshold:      0.1,
 	multilineContextLines:     4,
 	additionalIdentifiers:     nil,
@@ -93,6 +95,7 @@ func applyReportOptionsFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&reportOptions.excludeRegexps, "exclude-regexp", defaults.excludeRegexps, "exclude reports from a set of differences based on supplied regular expressions")
 	cmd.Flags().BoolVarP(&reportOptions.ignoreValueChanges, "ignore-value-changes", "v", defaults.ignoreValueChanges, "exclude changes in values")
 	cmd.Flags().BoolVar(&reportOptions.detectRenames, "detect-renames", defaults.detectRenames, "enable detection for renames (document level for Kubernetes resources)")
+	cmd.Flags().BoolVar(&reportOptions.marshalJsonStrings, "marshal-json-strings", defaults.marshalJsonStrings, "marshal Json strings for comparison, otherwise compare unformatted strings")
 
 	// Main output preferences
 	cmd.Flags().StringVarP(&reportOptions.style, "output", "o", defaults.style, "specify the output style, supported styles: human, brief, github, gitlab, gitea")


### PR DESCRIPTION
It is very common to have json strings in a yaml document when using `dyff` for Kubernetes resources. Doing a string comparison will return the entire string as a diff in the report. Marshalling the string to JSON, then comparing it, allows you to be specific about which field in the JSON string is changing.