### PR TITLE
feat: print dyff between output as yaml

### DIFF
--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -95,7 +95,7 @@ func applyReportOptionsFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&reportOptions.detectRenames, "detect-renames", defaults.detectRenames, "enable detection for renames (document level for Kubernetes resources)")
 
 	// Main output preferences
-	cmd.Flags().StringVarP(&reportOptions.style, "output", "o", defaults.style, "specify the output style, supported styles: human, brief, github, gitlab, gitea")
+	cmd.Flags().StringVarP(&reportOptions.style, "output", "o", defaults.style, "specify the output style, supported styles: human, brief, github, gitlab, gitea, yaml")
 	cmd.Flags().BoolVarP(&reportOptions.omitHeader, "omit-header", "b", defaults.omitHeader, "omit the dyff summary header")
 	cmd.Flags().BoolVarP(&reportOptions.exitWithCode, "set-exit-code", "s", defaults.exitWithCode, "set program exit code, with 0 meaning no difference, 1 for differences detected, and 255 for program error")
 
@@ -278,6 +278,11 @@ func writeReport(cmd *cobra.Command, report dyff.Report) error {
 				MultilineContextLines: reportOptions.multilineContextLines,
 				PrefixMultiline:       true,
 			},
+		}
+
+	case "yaml", "yml":
+		reportWriter = &dyff.YAMLReport{
+			Report: report,
 		}
 
 	case "brief", "short", "summary":

--- a/pkg/dyff/models.go
+++ b/pkg/dyff/models.go
@@ -45,6 +45,12 @@ type Detail struct {
 	Kind rune
 }
 
+type K8sMetadata struct {
+	APIVersion string
+	Kind       string
+	Metadata   map[string]string
+}
+
 // Diff encapsulates everything noteworthy about a difference
 type Diff struct {
 	Path    *ytbx.Path

--- a/pkg/dyff/output_yaml.go
+++ b/pkg/dyff/output_yaml.go
@@ -1,0 +1,146 @@
+package dyff
+
+import (
+	"bufio"
+	"github.com/gonvenience/neat"
+	"github.com/gonvenience/ytbx"
+	"io"
+)
+
+type YAMLReport struct {
+	Report
+}
+
+type YAMLReportDiff struct {
+	Details map[string]string
+	Path    string
+}
+
+type YAMLReportOutput struct {
+	APIVersion string            `yaml:"apiVersion"`
+	Kind       string            `yaml:"kind"`
+	Metadata   map[string]string `yaml:"metadata"`
+	Diffs      []YAMLReportDiff  `yaml:"diffs"`
+}
+
+// TODO: Support non-Kubernetes yaml documents
+func (report *YAMLReport) WriteReport(out io.Writer) error {
+	writer := bufio.NewWriter(out)
+	defer writer.Flush()
+	consolidatedDiff, err := report.consolidateDiff()
+	if err != nil {
+		return err
+	}
+	for file, diffs := range consolidatedDiff {
+		meta, err := K8sMetaFromName(file)
+		if err != nil {
+			return err
+		}
+		var d []YAMLReportDiff
+		for _, diff := range diffs {
+			d = append(d, YAMLReportDiff{
+				Path:    diff.Path,
+				Details: diff.Details,
+			})
+		}
+		data := YAMLReportOutput{
+			APIVersion: meta.APIVersion,
+			Kind:       meta.Kind,
+			Metadata:   meta.Metadata,
+			Diffs:      d,
+		}
+
+		// Use neat to format the YAML output
+		yamlData, err := neat.NewOutputProcessor(false, true, nil).ToYAML(data)
+		if err != nil {
+			return err
+		}
+
+		if _, err := writer.WriteString(yamlData); err != nil {
+			return err
+		}
+	}
+
+	_, _ = writer.WriteString("\n") // Ensure a newline at the end of the report
+	return nil
+}
+
+func (report *YAMLReport) consolidateDiff() (map[string][]YAMLReportDiff, error) {
+	fileDiffs := make(map[string][]YAMLReportDiff)
+
+	for _, diff := range report.Diffs {
+		deet := make(map[string]string)
+		switch len(diff.Details) {
+		case 1:
+			switch diff.Details[0].Kind {
+			case ADDITION:
+				ytbx.RestructureObject(diff.Details[0].To)
+				output, err := neat.NewOutputProcessor(false, true, nil).ToYAML(diff.Details[0].To)
+				if err != nil {
+					return nil, err
+				}
+				deet["to"] = output
+				deet["from"] = ""
+				deet["kind"] = "addition"
+			case REMOVAL:
+				ytbx.RestructureObject(diff.Details[0].From)
+				output, err := neat.NewOutputProcessor(false, true, nil).ToYAML(diff.Details[0].From)
+				if err != nil {
+					return nil, err
+				}
+				deet["to"] = ""
+				deet["from"] = output
+				deet["kind"] = "removal"
+			case MODIFICATION:
+				ytbx.RestructureObject(diff.Details[0].To)
+				outputTo, err := neat.NewOutputProcessor(false, true, nil).ToYAML(diff.Details[0].To)
+				ytbx.RestructureObject(diff.Details[0].From)
+				outputFrom, err := neat.NewOutputProcessor(false, true, nil).ToYAML(diff.Details[0].From)
+				if err != nil {
+					return nil, err
+				}
+				deet["to"] = outputTo
+				deet["from"] = outputFrom
+				deet["kind"] = "modification"
+			case ORDERCHANGE:
+				ytbx.RestructureObject(diff.Details[0].To)
+				outputTo, err := neat.NewOutputProcessor(false, true, nil).ToYAML(diff.Details[0].To)
+				ytbx.RestructureObject(diff.Details[0].From)
+				outputFrom, err := neat.NewOutputProcessor(false, true, nil).ToYAML(diff.Details[0].From)
+				if err != nil {
+					return nil, err
+				}
+				deet["to"] = outputTo
+				deet["from"] = outputFrom
+				deet["kind"] = "orderchange"
+			}
+		case 2:
+			for _, detail := range diff.Details {
+				switch detail.Kind {
+				case ADDITION:
+					ytbx.RestructureObject(detail.To)
+					output, err := neat.NewOutputProcessor(false, true, nil).ToYAML(detail.To)
+					if err != nil {
+						return nil, err
+					}
+					deet["to"] = output
+				case REMOVAL:
+					ytbx.RestructureObject(detail.From)
+					output, err := neat.NewOutputProcessor(false, true, nil).ToYAML(detail.From)
+					if err != nil {
+						return nil, err
+					}
+					deet["from"] = output
+				}
+			}
+			deet["kind"] = "modification"
+		}
+
+		fileDiffs[diff.Path.RootDescription()] = append(fileDiffs[diff.Path.RootDescription()], YAMLReportDiff{
+			Path:    diff.Path.String(),
+			Details: deet,
+		})
+	}
+
+	return fileDiffs, nil
+}


### PR DESCRIPTION
This PR is a first pass at an implementation for outputting the `dyff` report to yaml. This allows users to feed the `dyff` report back to `dyff` so you can compare the differences of two separate configuration files. This allow for you to create a record of differences that you expect and and then compare subsequent changes against.

Currently it only supports this for Kubernetes yaml as it is impossible to otherwise predict the number of documents that will be output. The Kubernetes file detection allows for that case

Attempts to 
resolve: #312 