### PR TITLE
Fix new `--use-indent-lines` wiring in code

### DIFF
--- a/.docs/commands/dyff_between.md
+++ b/.docs/commands/dyff_between.md
@@ -27,6 +27,7 @@ dyff between [flags] <from> <to>
   -v, --ignore-value-changes                exclude changes in values
       --detect-renames                      enable detection for renames (document level for Kubernetes resources) (default true)
   -o, --output string                       specify the output style, supported styles: human, brief, github, gitlab, gitea (default "human")
+      --use-indent-lines                    use indent lines in the output (default true)
   -b, --omit-header                         omit the dyff summary header
   -s, --set-exit-code                       set program exit code, with 0 meaning no difference, 1 for differences detected, and 255 for program error
   -l, --no-table-style                      do not place blocks next to each other, always use one row per text block

--- a/.docs/commands/dyff_last-applied.md
+++ b/.docs/commands/dyff_last-applied.md
@@ -28,6 +28,7 @@ dyff last-applied [flags]
   -v, --ignore-value-changes                exclude changes in values
       --detect-renames                      enable detection for renames (document level for Kubernetes resources) (default true)
   -o, --output string                       specify the output style, supported styles: human, brief, github, gitlab, gitea (default "human")
+      --use-indent-lines                    use indent lines in the output (default true)
   -b, --omit-header                         omit the dyff summary header
   -s, --set-exit-code                       set program exit code, with 0 meaning no difference, 1 for differences detected, and 255 for program error
   -l, --no-table-style                      do not place blocks next to each other, always use one row per text block

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -98,7 +98,7 @@ func applyReportOptionsFlags(cmd *cobra.Command) {
 
 	// Main output preferences
 	cmd.Flags().StringVarP(&reportOptions.style, "output", "o", defaults.style, "specify the output style, supported styles: human, brief, github, gitlab, gitea")
-	cmd.Flags().BoolVarP(&reportOptions.useIndentLines, "use-indent-lines", "u", defaults.useIndentLines, "use indent lines in the output")
+	cmd.Flags().BoolVar(&reportOptions.useIndentLines, "use-indent-lines", defaults.useIndentLines, "use indent lines in the output")
 	cmd.Flags().BoolVarP(&reportOptions.omitHeader, "omit-header", "b", defaults.omitHeader, "omit the dyff summary header")
 	cmd.Flags().BoolVarP(&reportOptions.exitWithCode, "set-exit-code", "s", defaults.exitWithCode, "set program exit code, with 0 meaning no difference, 1 for differences detected, and 255 for program error")
 
@@ -220,7 +220,7 @@ func writeReport(cmd *cobra.Command, report dyff.Report) error {
 		reportWriter = &dyff.HumanReport{
 			Report:                report,
 			Indent:                2,
-			UseIndentLines:        true,
+			UseIndentLines:        reportOptions.useIndentLines,
 			DoNotInspectCerts:     reportOptions.doNotInspectCerts,
 			NoTableStyle:          reportOptions.noTableStyle,
 			OmitHeader:            reportOptions.omitHeader,
@@ -238,7 +238,7 @@ func writeReport(cmd *cobra.Command, report dyff.Report) error {
 			HumanReport: dyff.HumanReport{
 				Report:                report,
 				Indent:                0,
-				UseIndentLines:        true,
+				UseIndentLines:        reportOptions.useIndentLines,
 				DoNotInspectCerts:     reportOptions.doNotInspectCerts,
 				NoTableStyle:          true,
 				OmitHeader:            true,
@@ -257,7 +257,7 @@ func writeReport(cmd *cobra.Command, report dyff.Report) error {
 			HumanReport: dyff.HumanReport{
 				Report:                report,
 				Indent:                0,
-				UseIndentLines:        true,
+				UseIndentLines:        reportOptions.useIndentLines,
 				DoNotInspectCerts:     reportOptions.doNotInspectCerts,
 				NoTableStyle:          true,
 				OmitHeader:            true,
@@ -276,7 +276,7 @@ func writeReport(cmd *cobra.Command, report dyff.Report) error {
 			HumanReport: dyff.HumanReport{
 				Report:                report,
 				Indent:                0,
-				UseIndentLines:        true,
+				UseIndentLines:        reportOptions.useIndentLines,
 				DoNotInspectCerts:     reportOptions.doNotInspectCerts,
 				NoTableStyle:          true,
 				OmitHeader:            true,


### PR DESCRIPTION
Use `reportOptions.useIndentLines` when generating reports.

Add new flag to generated Markdown documents.
