### PR TITLE
Bump `github.com/gonvenience/ytbx` to `v1.5.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gonvenience/neat v1.3.18
 	github.com/gonvenience/term v1.0.5
 	github.com/gonvenience/text v1.0.10
-	github.com/gonvenience/ytbx v1.4.9
+	github.com/gonvenience/ytbx v1.5.0
 	github.com/lucasb-eyer/go-colorful v1.4.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/gonvenience/term v1.0.5 h1:PYfBH7FB1V+tuuJl4KYrqG/tzAOUnvTy8IFa9YqYrJ
 github.com/gonvenience/term v1.0.5/go.mod h1:CYvcU7H3nE6eOP0gvGfYz4BjGJzM1GeNp+fx4IBWKLs=
 github.com/gonvenience/text v1.0.10 h1:QRqtC/KMk57K7y4jHi4HjLxf8u+tg+/tIRCS5afywNE=
 github.com/gonvenience/text v1.0.10/go.mod h1:qO4aTZGAXbeW7eJXK+94nIc5Uumz8Q5DphOFZex6JHI=
-github.com/gonvenience/ytbx v1.4.9 h1:8n9kmCTrS0dna863abBI50fQT6/2397jpsSZr6ZsnHo=
-github.com/gonvenience/ytbx v1.4.9/go.mod h1:5+Gl5Y0OxrO7Kp0qmrH8vTCAlY3whwBHN26KOReIe5o=
+github.com/gonvenience/ytbx v1.5.0 h1:6AbxnAWwyY+tMLEBENXC4m1j71Ubcv2+UaQmEA7rYv4=
+github.com/gonvenience/ytbx v1.5.0/go.mod h1:zxRSqmJ2sHOH+XyYFAPhyb7y+xjnRSRHLcNta5Ybcws=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/pprof v0.0.0-20260202012954-cb029daf43ef h1:xpF9fUHpoIrrjX24DURVKiwHcFpw19ndIs+FwTSMbno=

--- a/internal/cmd/cmds_test.go
+++ b/internal/cmd/cmds_test.go
@@ -554,8 +554,8 @@ spec.replicas  (apps/v1/Deployment/test)
 			Expect(out).To(BeEquivalentTo(`
 (root level)
 + four map entries added:
-  kind: ConfigMap
   apiVersion: v1
+  kind: ConfigMap
   metadata:
     name: atlantis-repo-config
     namespace: default


### PR DESCRIPTION
Fixes #635 

Bump `github.com/gonvenience/ytbx` to `v1.5.0`.

Fix test case that now has a changed order.