### PR TITLE
Omit YAML document start marker for single-document output

### DIFF
--- a/assets/kubernetes/multi-docs-file-level/expected-dyff.human
+++ b/assets/kubernetes/multi-docs-file-level/expected-dyff.human
@@ -6,7 +6,6 @@ metadata  (v1/Service/foo)
 
 (root level)  (v1/Service/foo-2)
 - one document removed:
-  ---
   apiVersion: v1
   kind: Service
   metadata:
@@ -17,7 +16,6 @@ metadata  (v1/Service/foo)
 
 (root level)  (v1/Service/bar)
 + one document added:
-  ---
   apiVersion: v1
   kind: Service
   metadata:
@@ -28,7 +26,6 @@ metadata  (v1/Service/foo)
 
 (root level)  (v1/Service/baz)
 + one document added:
-  ---
   apiVersion: v1
   kind: Service
   metadata:

--- a/assets/multidocs/simple/file.yaml
+++ b/assets/multidocs/simple/file.yaml
@@ -1,0 +1,5 @@
+---
+foo: bar
+
+---
+bar: foo

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/caarlos0/env/v11 v11.4.0
 	github.com/gonvenience/bunt v1.4.3
 	github.com/gonvenience/idem v0.0.3
-	github.com/gonvenience/neat v1.3.18
+	github.com/gonvenience/neat v1.3.20
 	github.com/gonvenience/term v1.0.5
 	github.com/gonvenience/text v1.0.10
 	github.com/gonvenience/ytbx v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/gonvenience/bunt v1.4.3 h1:MLd8YWu1Vl1tiL+XfXJvVA9kL71yQT0N+x7gXVH9H7
 github.com/gonvenience/bunt v1.4.3/go.mod h1:ggA6odP6FNOh50mGxxytSSJTs2Ghy5Veq9wIVSbuoAw=
 github.com/gonvenience/idem v0.0.3 h1:rZ2f17JU5GHa3b5M5R2fClz0dYN3EFGhHHGo3AZz/1U=
 github.com/gonvenience/idem v0.0.3/go.mod h1:ChZ+RP8e30+uCBcCIzN/0di6lTO2PucjemgKfzQUQEw=
-github.com/gonvenience/neat v1.3.18 h1:WxWoXhsTHA6CStNrGgSEjGTt5MwIm+7Xs+VZmQIuXZA=
-github.com/gonvenience/neat v1.3.18/go.mod h1:DTaEyHIOjSkMa066EoZZl3k5KCG/rFGE67n0cjm/9qk=
+github.com/gonvenience/neat v1.3.20 h1:KdevSy5GLb3h1U5AYGw3NwW9FAAU2MWfrtsDHzYaKOg=
+github.com/gonvenience/neat v1.3.20/go.mod h1:GbVes855L3QYFkDg9pnxHe/FQVsr1Tl+ME0fyOZO4Lg=
 github.com/gonvenience/term v1.0.5 h1:PYfBH7FB1V+tuuJl4KYrqG/tzAOUnvTy8IFa9YqYrJY=
 github.com/gonvenience/term v1.0.5/go.mod h1:CYvcU7H3nE6eOP0gvGfYz4BjGJzM1GeNp+fx4IBWKLs=
 github.com/gonvenience/text v1.0.10 h1:QRqtC/KMk57K7y4jHi4HjLxf8u+tg+/tIRCS5afywNE=

--- a/internal/cmd/cmds_test.go
+++ b/internal/cmd/cmds_test.go
@@ -51,96 +51,6 @@ var _ = Describe("command line tool flags", func() {
 		})
 	})
 
-	Context("yaml command", func() {
-		Context("creating yaml output", func() {
-			It("should not create YAML output that is not valid", func() {
-				filename := createTestFile(`{"a": ",", "foo": {"bar": "*", "dash": "-"}}`)
-				defer os.Remove(filename)
-
-				out, err := dyff("yaml", filename)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(out).To(BeEquivalentTo(`---
-a: ","
-foo:
-  bar: "*"
-  dash: "-"
-
-`))
-			})
-		})
-
-		Context("using restructure", func() {
-			Context("to write the file to STDOUT", func() {
-				It("should write a YAML file to STDOUT using restructure feature", func() {
-					filename := createTestFile(`---
-list:
-- aaa: bbb
-  name: one
-`)
-					defer os.Remove(filename)
-
-					out, err := dyff("yaml", "--restructure", filename)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(out).To(BeEquivalentTo(`---
-list:
-- name: one
-  aaa: bbb
-
-`))
-				})
-
-				It("should write a YAML file with multiple documents to STDOUT using restructure feature", func() {
-					out, err := dyff("yaml", "--plain", "--restructure", assets("issues", "issue-133", "input.yml"))
-					Expect(err).ToNot(HaveOccurred())
-					Expect(out).To(BeEquivalentTo(`---
-name: one
-bar: foo
-foo: bar
----
-name: two
-Foo: Bar
-Bar: Foo
----
-name: three
-foobar: foobar
-`))
-				})
-			})
-
-			Context("to write the file in-place", func() {
-				It("should write a YAML file in place using restructure feature", func() {
-					filename := createTestFile(`---
-list:
-- aaa: bbb
-  name: one
-`)
-					defer os.Remove(filename)
-
-					out, err := dyff("yaml", "--restructure", "--in-place", filename)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(out).To(BeEmpty())
-
-					data, err := os.ReadFile(filename)
-					Expect(err).To(BeNil())
-					Expect(string(data)).To(BeEquivalentTo(`---
-list:
-  - name: one
-    aaa: bbb
-`))
-
-				})
-			})
-
-			Context("incorrect usage", func() {
-				It("should fail to write a YAML when in place and STDIN are used at the same time", func() {
-					_, err := dyff("yaml", "--in-place", "-")
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(ContainSubstring("incompatible flags: cannot use in-place flag in combination with input"))
-				})
-			})
-		})
-	})
-
 	Context("json command", func() {
 		It("should write a JSON file in place using restructure feature", func() {
 			filename := createTestFile(`{"list":[{"aaa":"bbb","name":"one"}]}`)
@@ -596,7 +506,6 @@ spec.replicas  (apps/v1/Deployment/test)
 			expected := `
 (root level)  (v1/Namespace/test)
 - one document removed:
-  ---
   apiVersion: v1
   kind: Namespace
   metadata:

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -133,10 +133,11 @@ func reportOptionsFlags() []*pflag.FlagSet {
 // OutputWriter encapsulates the required fields to define the look and feel of
 // the output
 type OutputWriter struct {
-	PlainMode        bool
-	Restructure      bool
-	OmitIndentHelper bool
-	OutputStyle      string
+	PlainMode                  bool
+	Restructure                bool
+	OmitIndentHelper           bool
+	EnforceDocumentStartMarker bool
+	OutputStyle                string
 }
 
 func humanReadableFilename(filename string) string {
@@ -191,14 +192,20 @@ func (w *OutputWriter) write(writer io.Writer, filename string) error {
 
 		switch {
 		case w.PlainMode && w.OutputStyle == "json":
-			output, err := neat.NewOutputProcessor(false, false, &neat.DefaultColorSchema).ToCompactJSON(document)
+			outputProcessor := neat.NewOutputProcessorWithDefaults()
+
+			output, err := outputProcessor.ToCompactJSON(document)
 			if err != nil {
 				return err
 			}
+
 			_, _ = fmt.Fprintln(writer, output)
 
 		case w.PlainMode && w.OutputStyle == "yaml":
-			_, _ = fmt.Fprintln(writer, "---")
+			if len(inputFile.Documents) != 1 || w.EnforceDocumentStartMarker {
+				_, _ = fmt.Fprintln(writer, "---")
+			}
+
 			encoder := yamlv3.NewEncoder(writer)
 			encoder.SetIndent(2)
 
@@ -211,17 +218,30 @@ func (w *OutputWriter) write(writer io.Writer, filename string) error {
 			}
 
 		case w.OutputStyle == "json":
-			output, err := neat.NewOutputProcessor(!w.OmitIndentHelper, true, &neat.DefaultColorSchema).ToJSON(document)
+			outputProcessor := neat.NewOutputProcessorWithDefaults().
+				UseIndentLines(!w.OmitIndentHelper).
+				BoldKeys(true).
+				ColorSchema(neat.DefaultColorSchema)
+
+			output, err := outputProcessor.ToJSON(document)
 			if err != nil {
 				return err
 			}
+
 			_, _ = fmt.Fprintln(writer, output)
 
 		case w.OutputStyle == "yaml":
-			output, err := neat.NewOutputProcessor(!w.OmitIndentHelper, true, &neat.DefaultColorSchema).ToYAML(document)
+			outputProcessor := neat.NewOutputProcessorWithDefaults().
+				UseIndentLines(!w.OmitIndentHelper).
+				BoldKeys(true).
+				EnforceDocumentStartMarker(len(inputFile.Documents) > 1).
+				ColorSchema(neat.DefaultColorSchema)
+
+			output, err := outputProcessor.ToYAML(document)
 			if err != nil {
 				return err
 			}
+
 			_, _ = fmt.Fprintln(writer, output)
 		}
 	}

--- a/internal/cmd/yaml.go
+++ b/internal/cmd/yaml.go
@@ -30,10 +30,12 @@ import (
 )
 
 type yamlCmdOptions struct {
-	plainMode        bool
-	restructure      bool
-	omitIndentHelper bool
-	inplace          bool
+	restructure bool
+	inplace     bool
+
+	plainMode                  bool
+	omitIndentHelper           bool
+	enforceDocumentStartMarker bool
 }
 
 var yamlCmdSettings yamlCmdOptions
@@ -50,10 +52,11 @@ Converts input document into YAML format while preserving the order of all keys.
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		writer := &OutputWriter{
-			OutputStyle:      "yaml",
-			PlainMode:        yamlCmdSettings.plainMode,
-			Restructure:      yamlCmdSettings.restructure,
-			OmitIndentHelper: yamlCmdSettings.omitIndentHelper,
+			OutputStyle:                "yaml",
+			PlainMode:                  yamlCmdSettings.plainMode,
+			Restructure:                yamlCmdSettings.restructure,
+			OmitIndentHelper:           yamlCmdSettings.omitIndentHelper,
+			EnforceDocumentStartMarker: yamlCmdSettings.enforceDocumentStartMarker,
 		}
 
 		var errs []error
@@ -88,6 +91,8 @@ func init() {
 
 	yamlCmd.Flags().BoolVarP(&yamlCmdSettings.plainMode, "plain", "p", false, "output in plain style without any highlighting")
 	yamlCmd.Flags().BoolVarP(&yamlCmdSettings.restructure, "restructure", "r", false, "restructure map keys in reasonable order")
-	yamlCmd.Flags().BoolVarP(&yamlCmdSettings.omitIndentHelper, "omit-indent-helper", "O", false, "omit indent helper lines in highlighted output")
 	yamlCmd.Flags().BoolVarP(&yamlCmdSettings.inplace, "in-place", "i", false, "overwrite input file with output of this command")
+
+	yamlCmd.Flags().BoolVarP(&yamlCmdSettings.omitIndentHelper, "omit-indent-helper", "O", false, "omit indent helper lines in highlighted output")
+	yamlCmd.Flags().BoolVar(&yamlCmdSettings.enforceDocumentStartMarker, "enforce-document-start-marker", false, "print YAML document start marker even when not necessarily required")
 }

--- a/internal/cmd/yaml_test.go
+++ b/internal/cmd/yaml_test.go
@@ -1,0 +1,164 @@
+// Copyright © 2019 The Homeport Team
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/gonvenience/term"
+)
+
+var _ = Describe("using dyff yaml", func() {
+	BeforeEach(func() {
+		term.FixedTerminalWidth = 250
+		term.FixedTerminalHeight = 40
+	})
+
+	AfterEach(func() {
+		term.FixedTerminalWidth = -1
+		term.FixedTerminalHeight = -1
+	})
+
+	Context("streaming to StdOut", func() {
+		It("should write single document without document start marker in default mode", func() {
+			filename := createTestFile(`{"foo": "bar"}`)
+			defer os.Remove(filename)
+
+			out, err := dyff("yaml", filename)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(BeEquivalentTo(`foo: bar
+
+`))
+		})
+
+		It("should write single document without document start marker in plain mode", func() {
+			filename := createTestFile(`{"foo": "bar"}`)
+			defer os.Remove(filename)
+
+			out, err := dyff("yaml", "--plain", filename)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(BeEquivalentTo(`foo: bar
+`))
+		})
+
+		It("should write multi document with document start marker in default mode", func() {
+			out, err := dyff("yaml", assets("multidocs/simple/file.yaml"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(BeEquivalentTo(`---
+foo: bar
+
+---
+bar: foo
+
+`))
+		})
+
+		It("should write multi document with document start marker in plain mode", func() {
+			out, err := dyff("yaml", "--plain", assets("multidocs/simple/file.yaml"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(BeEquivalentTo(`---
+foo: bar
+---
+bar: foo
+`))
+		})
+
+		It("should quote all string that have special meaning in YAML", func() {
+			filename := createTestFile(`{"a": ",", "foo": {"bar": "*", "dash": "-"}}`)
+			defer os.Remove(filename)
+
+			out, err := dyff("yaml", filename)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(BeEquivalentTo(`a: ","
+foo:
+  bar: "*"
+  dash: "-"
+
+`))
+		})
+
+		It("should restructure (reorder) fields", func() {
+			filename := createTestFile(`---
+list:
+- aaa: bbb
+  name: one
+`)
+			defer os.Remove(filename)
+
+			out, err := dyff("yaml", "--restructure", filename)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(BeEquivalentTo(`list:
+- name: one
+  aaa: bbb
+
+`))
+		})
+
+		It("should restructure (reorder) fields in multi-document YAML", func() {
+			out, err := dyff("yaml", "--plain", "--restructure", assets("issues", "issue-133", "input.yml"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(BeEquivalentTo(`---
+name: one
+bar: foo
+foo: bar
+---
+name: two
+Foo: Bar
+Bar: Foo
+---
+name: three
+foobar: foobar
+`))
+		})
+	})
+
+	Context("writing in-place", func() {
+		It("should write a YAML file in place using restructure feature", func() {
+			filename := createTestFile(`---
+list:
+- aaa: bbb
+  name: one
+`)
+			defer os.Remove(filename)
+
+			out, err := dyff("yaml", "--restructure", "--in-place", filename)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(out).To(BeEmpty())
+
+			data, err := os.ReadFile(filename)
+			Expect(err).To(BeNil())
+			Expect(string(data)).To(BeEquivalentTo(`list:
+  - name: one
+    aaa: bbb
+`))
+
+		})
+	})
+
+	It("should fail to write a YAML when in place and STDIN are used at the same time", func() {
+		_, err := dyff("yaml", "--in-place", "-")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("incompatible flags: cannot use in-place flag in combination with input"))
+	})
+})

--- a/pkg/dyff/colors.go
+++ b/pkg/dyff/colors.go
@@ -160,31 +160,41 @@ func (c *BuntColorizer) StylizeHeader(header string) string {
 }
 
 func (c *BuntColorizer) YAMLInRedishColors(input interface{}, useIndentLines bool) (string, error) {
-	return neat.NewOutputProcessor(useIndentLines, true, &map[string]colorful.Color{
-		"keyColor":           bunt.FireBrick,
-		"indentLineColor":    {R: 0.2, G: 0, B: 0},
-		"scalarDefaultColor": bunt.LightCoral,
-		"boolColor":          bunt.LightCoral,
-		"floatColor":         bunt.LightCoral,
-		"intColor":           bunt.LightCoral,
-		"multiLineTextColor": bunt.DarkSalmon,
-		"nullColor":          bunt.Salmon,
-		"emptyStructures":    bunt.LightSalmon,
-		"dashColor":          bunt.FireBrick,
-	}).ToYAML(input)
+	return neat.NewOutputProcessorWithDefaults().
+		BoldKeys(true).
+		UseIndentLines(useIndentLines).
+		EnforceDocumentStartMarker(false).
+		ColorSchema(map[string]colorful.Color{
+			"keyColor":           bunt.FireBrick,
+			"indentLineColor":    {R: 0.2, G: 0, B: 0},
+			"scalarDefaultColor": bunt.LightCoral,
+			"boolColor":          bunt.LightCoral,
+			"floatColor":         bunt.LightCoral,
+			"intColor":           bunt.LightCoral,
+			"multiLineTextColor": bunt.DarkSalmon,
+			"nullColor":          bunt.Salmon,
+			"emptyStructures":    bunt.LightSalmon,
+			"dashColor":          bunt.FireBrick,
+		}).
+		ToYAML(input)
 }
 
 func (c *BuntColorizer) YAMLInGreenishColors(input interface{}, useIndentLines bool) (string, error) {
-	return neat.NewOutputProcessor(useIndentLines, true, &map[string]colorful.Color{
-		"keyColor":           bunt.Green,
-		"indentLineColor":    {R: 0, G: 0.2, B: 0},
-		"scalarDefaultColor": bunt.LimeGreen,
-		"boolColor":          bunt.LimeGreen,
-		"floatColor":         bunt.LimeGreen,
-		"intColor":           bunt.LimeGreen,
-		"multiLineTextColor": bunt.OliveDrab,
-		"nullColor":          bunt.Olive,
-		"emptyStructures":    bunt.DarkOliveGreen,
-		"dashColor":          bunt.Green,
-	}).ToYAML(input)
+	return neat.NewOutputProcessorWithDefaults().
+		BoldKeys(true).
+		UseIndentLines(useIndentLines).
+		EnforceDocumentStartMarker(false).
+		ColorSchema(map[string]colorful.Color{
+			"keyColor":           bunt.Green,
+			"indentLineColor":    {R: 0, G: 0.2, B: 0},
+			"scalarDefaultColor": bunt.LimeGreen,
+			"boolColor":          bunt.LimeGreen,
+			"floatColor":         bunt.LimeGreen,
+			"intColor":           bunt.LimeGreen,
+			"multiLineTextColor": bunt.OliveDrab,
+			"nullColor":          bunt.Olive,
+			"emptyStructures":    bunt.DarkOliveGreen,
+			"dashColor":          bunt.Green,
+		}).
+		ToYAML(input)
 }

--- a/pkg/dyff/output_human.go
+++ b/pkg/dyff/output_human.go
@@ -619,7 +619,10 @@ func yamlString(input interface{}) (string, error) {
 		}
 	}
 
-	return neat.NewOutputProcessor(false, true, nil).ToYAML(input)
+	return neat.NewOutputProcessorWithDefaults().
+		UseIndentLines(false).
+		BoldKeys(true).
+		ToYAML(input)
 }
 
 func isMinorChange(from string, to string, minorChangeThreshold float64) bool {


### PR DESCRIPTION
By popular demand: Single-document YAML output no longer includes a leading `---` marker by default, aligning with standard YAML conventions. Multi-document files still emit the marker for each document. A new `--enforce-document-start-marker` flag is added to opt back into always printing the marker.
