### PR TITLE
fix: avoid mutating YAML nodes in-place when FormatStrings is enabled

### DIFF
--- a/pkg/dyff/compare_test.go
+++ b/pkg/dyff/compare_test.go
@@ -1187,5 +1187,19 @@ b: bar
 				}
 			})
 		})
+
+		Context("when FormatStrings is enabled", func() {
+			It("should report no differences when comparing identical named-entry lists", func() {
+				doc := yml(`
+spec:
+  items:
+  - id: "1"
+  - id: "2"
+`)
+				results, err := compare(doc, doc, dyff.FormatStrings(true))
+				Expect(err).ToNot(HaveOccurred())
+				Expect(results).To(BeEmpty())
+			})
+		})
 	})
 })

--- a/pkg/dyff/core.go
+++ b/pkg/dyff/core.go
@@ -692,8 +692,13 @@ func (compare *compare) nodeValues(path ytbx.Path, from *yamlv3.Node, to *yamlv3
 
 		if fromValue, ok := jsonFormat(from.Value); ok {
 			if toValue, ok := jsonFormat(to.Value); ok {
-				from.Value = fromValue
-				to.Value = toValue
+				fromCopy := *from
+				fromCopy.Value = fromValue
+				from = &fromCopy
+
+				toCopy := *to
+				toCopy.Value = toValue
+				to = &toCopy
 			}
 		}
 	}


### PR DESCRIPTION
FormatStrings was modifying scalar node values directly on the caller's nodes, which corrupted the toNames slice collected after the comparison loop in namedEntryLists. This caused false order-change diffs when comparing identical named-entry lists.

Fix by copying the nodes before modifying their Value fields so the originals remain unmodified for the rest of the comparison pipeline.

Fixes issue #676