### PR TITLE
fix: correct unbalanced parentheses in output

### DIFF
--- a/assets/kubernetes/configmaps/expected-dyff-spruce.github
+++ b/assets/kubernetes/configmaps/expected-dyff-spruce.github
@@ -13,7 +13,7 @@
 [38;2;105;105;105m  # impersonationProxyServerPort may be set here, although other YAML references to the default port (8444) may also need to be updated[0m
 [38;2;105;105;105m  names:[0m
 [38;2;105;105;105m  [0m
-[38;2;105;105;105m  [five lines unchanged)][0m
+[38;2;105;105;105m  [five lines unchanged][0m
 [38;2;105;105;105m  [0m
 [38;2;105;105;105m    impersonationTLSCertificateSecret: pinniped-concierge-impersonation-proxy-tls-serving-certificate[0m
 [38;2;105;105;105m    impersonationCACertificateSecret: pinniped-concierge-impersonation-proxy-ca-certificate[0m

--- a/assets/kubernetes/configmaps/expected-dyff-spruce.human
+++ b/assets/kubernetes/configmaps/expected-dyff-spruce.human
@@ -13,7 +13,7 @@
   [38;2;105;105;105m    # impersonationProxyServerPort may be set here, although other YAML references to the default port (8444) may also need to be updated[0m
   [38;2;105;105;105m    names:[0m
   [38;2;105;105;105m    [0m
-  [38;2;105;105;105m    [five lines unchanged)][0m
+  [38;2;105;105;105m    [five lines unchanged][0m
   [38;2;105;105;105m    [0m
   [38;2;105;105;105m      impersonationTLSCertificateSecret: pinniped-concierge-impersonation-proxy-tls-serving-certificate[0m
   [38;2;105;105;105m      impersonationCACertificateSecret: pinniped-concierge-impersonation-proxy-ca-certificate[0m

--- a/assets/kubernetes/rename/expected-dyff.human
+++ b/assets/kubernetes/rename/expected-dyff.human
@@ -6,7 +6,7 @@ data.pinniped.yaml
       api:
         servingCertificate:
       
-      [two lines unchanged)]
+      [two lines unchanged]
       
       apiGroupSuffix: pinniped.dev
       # aggregatedAPIServerPort may be set here, although other YAML references to the default port (10250) may also need to be updated
@@ -18,7 +18,7 @@ data.pinniped.yaml
         apiService: pinniped-concierge-api
         impersonationLoadBalancerService: pinniped-concierge-impersonation-proxy-load-balancer
       
-      [five lines unchanged)]
+      [five lines unchanged]
       
       labels: {"app": "pinniped-concierge"}
       kubeCertAgent:

--- a/assets/multiline/expected-dyff-spruce.github
+++ b/assets/multiline/expected-dyff-spruce.github
@@ -43,7 +43,7 @@
 [38;2;105;105;105m  Begin line 3[0m
 [38;2;105;105;105m  Begin line 4[0m
 [38;2;105;105;105m  [0m
-[38;2;105;105;105m  [four lines unchanged)][0m
+[38;2;105;105;105m  [four lines unchanged][0m
 [38;2;105;105;105m  [0m
 [38;2;105;105;105m  PreChange line 1[0m
 [38;2;105;105;105m  PreChange line 2[0m
@@ -58,7 +58,7 @@
 [38;2;105;105;105m  PostChange line 3[0m
 [38;2;105;105;105m  PostChange line 4[0m
 [38;2;105;105;105m  [0m
-[38;2;105;105;105m  [three lines unchanged)][0m
+[38;2;105;105;105m  [three lines unchanged][0m
 [38;2;105;105;105m  [0m
 [38;2;105;105;105m  PreAdd line 1[0m
 [38;2;105;105;105m  PreAdd line 2[0m
@@ -71,7 +71,7 @@
 [38;2;105;105;105m  PostAdd line 3[0m
 [38;2;105;105;105m  PostAdd line 4[0m
 [38;2;105;105;105m  [0m
-[38;2;105;105;105m  [two lines unchanged)][0m
+[38;2;105;105;105m  [two lines unchanged][0m
 [38;2;105;105;105m  [0m
 [38;2;105;105;105m  PreDelete line 1[0m
 [38;2;105;105;105m  PreDelete line 2[0m
@@ -85,7 +85,7 @@
 [38;2;105;105;105m  PostDelete line 3[0m
 [38;2;105;105;105m  PostDelete line 4[0m
 [38;2;105;105;105m  [0m
-[38;2;105;105;105m  [22 lines unchanged)][0m
+[38;2;105;105;105m  [22 lines unchanged][0m
 [38;2;105;105;105m  [0m
 [38;2;105;105;105m  End line 1[0m
 [38;2;105;105;105m  End line 2[0m

--- a/assets/multiline/expected-dyff-spruce.human
+++ b/assets/multiline/expected-dyff-spruce.human
@@ -45,7 +45,7 @@
   [38;2;105;105;105m    Begin line 3[0m
   [38;2;105;105;105m    Begin line 4[0m
   [38;2;105;105;105m    [0m
-  [38;2;105;105;105m    [four lines unchanged)][0m
+  [38;2;105;105;105m    [four lines unchanged][0m
   [38;2;105;105;105m    [0m
   [38;2;105;105;105m    PreChange line 1[0m
   [38;2;105;105;105m    PreChange line 2[0m
@@ -60,7 +60,7 @@
   [38;2;105;105;105m    PostChange line 3[0m
   [38;2;105;105;105m    PostChange line 4[0m
   [38;2;105;105;105m    [0m
-  [38;2;105;105;105m    [three lines unchanged)][0m
+  [38;2;105;105;105m    [three lines unchanged][0m
   [38;2;105;105;105m    [0m
   [38;2;105;105;105m    PreAdd line 1[0m
   [38;2;105;105;105m    PreAdd line 2[0m
@@ -73,7 +73,7 @@
   [38;2;105;105;105m    PostAdd line 3[0m
   [38;2;105;105;105m    PostAdd line 4[0m
   [38;2;105;105;105m    [0m
-  [38;2;105;105;105m    [two lines unchanged)][0m
+  [38;2;105;105;105m    [two lines unchanged][0m
   [38;2;105;105;105m    [0m
   [38;2;105;105;105m    PreDelete line 1[0m
   [38;2;105;105;105m    PreDelete line 2[0m
@@ -87,7 +87,7 @@
   [38;2;105;105;105m    PostDelete line 3[0m
   [38;2;105;105;105m    PostDelete line 4[0m
   [38;2;105;105;105m    [0m
-  [38;2;105;105;105m    [22 lines unchanged)][0m
+  [38;2;105;105;105m    [22 lines unchanged][0m
   [38;2;105;105;105m    [0m
   [38;2;105;105;105m    End line 1[0m
   [38;2;105;105;105m    End line 2[0m

--- a/pkg/dyff/output_human.go
+++ b/pkg/dyff/output_human.go
@@ -396,7 +396,7 @@ func (report *HumanReport) writeStringDiff(output stringWriter, from string, to 
 				if upper <= lower {
 					val = strings.Join(lines, "\n")
 				} else {
-					val = fmt.Sprintf("%s\n\n[%s unchanged)]\n\n%s",
+					val = fmt.Sprintf("%s\n\n[%s unchanged]\n\n%s",
 						strings.Join(lines[:lower], "\n"),
 						text.Plural((upper-lower), "line"),
 						strings.Join(lines[upper:], "\n"))


### PR DESCRIPTION
This PR removes what I believe is an unintentional closing parenthesis (there's no opening one) from the `[n lines unchanged)]` output. I came across this when I was grepping through output, and it made me think I was missing some context from earlier hidden lines for the line I was looking at.